### PR TITLE
Restore RuStore AppUpdate + fix Android 16 bugs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,6 +112,8 @@ dependencies {
     implementation(project(Libs.project_robokassa_sdk))
     implementation (Libs.ksp_api)
     implementation(Libs.mytracker_sdk)
+    implementation(platform(Libs.rustore_bom))
+    implementation(Libs.rustore_sdk_appupdate)
 
     implementation(platform(Libs.ru_ok_tracer_platform))
     implementation(Libs.ru_ok_tracer_tracer_crash_report)

--- a/app/src/main/java/com/z_company/loco_driver/StartApp.kt
+++ b/app/src/main/java/com/z_company/loco_driver/StartApp.kt
@@ -9,6 +9,7 @@ import com.z_company.data_local.setting.di.roomSalarySettingModule
 import com.z_company.data_local.setting.di.roomSettingsModule
 import com.z_company.loco_driver.di.repositoryModule
 import com.z_company.loco_driver.di.resourcesModule
+import com.z_company.loco_driver.di.updateModule
 import com.z_company.loco_driver.di.useCaseModule
 import com.z_company.loco_driver.di.viewModelModule
 import org.koin.android.ext.koin.androidContext
@@ -42,32 +43,30 @@ class StartApp : Application() {
                 roomRouteModule,
                 repositoryModule,
                 useCaseModule,
-                resourcesModule
+                resourcesModule,
+                updateModule
             )
         }
 
-        val workManager = WorkManager.getInstance(this)
-        val workInfos = workManager.getWorkInfosForUniqueWork("sync_work").get()
+        // KEEP гарантирует что дубликат не создастся если задача уже запланирована.
+        // Убран блокирующий .get() на главном потоке — вызывал ANR на Android 16.
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
 
-        if (workInfos.isEmpty()) {
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
+        val periodicWorkRequest = PeriodicWorkRequestBuilder<SyncWorker>(
+            repeatInterval = 36,
+            repeatIntervalTimeUnit = TimeUnit.HOURS
+        )
+            .setInitialDelay(6, TimeUnit.HOURS)
+            .setConstraints(constraints)
+            .build()
 
-            val periodicWorkRequest = PeriodicWorkRequestBuilder<SyncWorker>(
-                repeatInterval = 36,
-                repeatIntervalTimeUnit = TimeUnit.HOURS
+        WorkManager.getInstance(this)
+            .enqueueUniquePeriodicWork(
+                "sync_work",
+                ExistingPeriodicWorkPolicy.KEEP,
+                periodicWorkRequest
             )
-                .setInitialDelay(6, TimeUnit.HOURS)
-                .setConstraints(constraints)
-                .build()
-
-            WorkManager.getInstance(this)
-                .enqueueUniquePeriodicWork(
-                    "sync_work",
-                    ExistingPeriodicWorkPolicy.KEEP,
-                    periodicWorkRequest
-                )
-        }
     }
 }

--- a/app/src/main/java/com/z_company/loco_driver/di/UpdateModule.kt
+++ b/app/src/main/java/com/z_company/loco_driver/di/UpdateModule.kt
@@ -1,0 +1,12 @@
+package com.z_company.loco_driver.di
+
+import org.koin.android.ext.koin.androidApplication
+import org.koin.dsl.module
+import ru.rustore.sdk.appupdate.manager.RuStoreAppUpdateManager
+import ru.rustore.sdk.appupdate.manager.factory.RuStoreAppUpdateManagerFactory
+
+val updateModule = module {
+    single<RuStoreAppUpdateManager> {
+        RuStoreAppUpdateManagerFactory.create(androidApplication())
+    }
+}

--- a/app/src/main/java/com/z_company/loco_driver/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/z_company/loco_driver/viewmodel/MainViewModel.kt
@@ -42,16 +42,21 @@ class MainViewModel : ViewModel(), KoinComponent, DefaultLifecycleObserver {
     private var saveCalendarInLocalJob: Job? = null
     private var setDefaultSetting: Job? = null
 
-    val showFirstPresentation = sharedPreferenceStorage.tokenIsFirstAppEntry()
-    val showUpdatePresentation =
-        sharedPreferenceStorage.isShowUpdatePresentation() && !sharedPreferenceStorage.tokenIsFirstAppEntry()
+    // Флаг первого запуска — считываем ОДИН РАЗ синхронно до любых async операций
+    val isFirstEntry = sharedPreferenceStorage.tokenIsFirstAppEntry()
+
+    val showFirstPresentation = isFirstEntry
+    val showUpdatePresentation = sharedPreferenceStorage.isShowUpdatePresentation() && !isFirstEntry
 
     private val _appInitialized = MutableStateFlow(false)
     val appInitialized: StateFlow<Boolean> = _appInitialized.asStateFlow()
 
     init {
-        if (sharedPreferenceStorage.tokenIsFirstAppEntry()) {
+        if (isFirstEntry) {
             sharedPreferenceStorage.setIsMigrated(true)
+            // Сразу сбрасываем флаг синхронно (commit), чтобы даже при завершении процесса
+            // на Android 16 он не остался true и не сбросил настройки при следующем запуске
+            sharedPreferenceStorage.setTokenIsFirstAppEntry(false)
         }
         viewModelScope.launch {
             loadCalendar()
@@ -156,7 +161,7 @@ class MainViewModel : ViewModel(), KoinComponent, DefaultLifecycleObserver {
                     settingsUseCase.updateMonthOfYearInUserSetting(
                         searchMonthOfYear ?: calendar.first()
                     ).collect {}
-                    if (sharedPreferenceStorage.tokenIsFirstAppEntry()) {
+                    if (isFirstEntry) {
                         setDefaultSettings(searchMonthOfYear ?: calendar.first())
                     }
                 }

--- a/data_local/src/main/java/com/z_company/data_local/SharedPreferenceStorage.kt
+++ b/data_local/src/main/java/com/z_company/data_local/SharedPreferenceStorage.kt
@@ -91,7 +91,9 @@ class SharedPreferenceStorage(application: Application) : SharedPreferencesRepos
     }
 
     override fun setTokenIsFirstAppEntry(value: Boolean) {
-        editor.putBoolean(TOKEN_IS_FIRST_APP_ENTRY_TAG, value).apply()
+        // commit() вместо apply() — синхронная запись, защита от потери данных
+        // при завершении процесса на Android 16 (process death)
+        editor.putBoolean(TOKEN_IS_FIRST_APP_ENTRY_TAG, value).commit()
     }
 
     fun setTokenIsSyncEnable(value: Boolean) {

--- a/features/route/build.gradle.kts
+++ b/features/route/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(Libs.vkId)
     implementation(platform(Libs.rustore_bom))
     implementation(Libs.rustore_review)
+    implementation(Libs.rustore_sdk_appupdate)
     implementation(Libs.gson)
 
     implementation(project(Libs.project_core_android))

--- a/features/route/src/main/java/com/z_company/route/navigation/HomeDestination.kt
+++ b/features/route/src/main/java/com/z_company/route/navigation/HomeDestination.kt
@@ -48,6 +48,8 @@ fun HomeDestination(
         homeRestValue = previewRouteUiState.homeRest,
         offsetInMoscow = uiState.offsetInMoscow,
         syncRoute = homeViewModel::syncRoute,
+        completeUpdateRequested = homeViewModel::completeUpdateRequested,
+        updateEvent = homeViewModel.updateEvents,
         setFavoriteState = homeViewModel::setFavoriteRoute,
         dateAndTimeConverter = uiState.dateAndTimeConverter,
         extendedServicePhaseTime = uiState.extendedServicePhaseTime,

--- a/features/route/src/main/java/com/z_company/route/ui/HomeScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/HomeScreen.kt
@@ -110,6 +110,7 @@ import com.z_company.route.component.BottomSheetAction
 import com.z_company.route.component.ItemHomeScreen
 import com.z_company.route.component.LinearPagerIndicator
 import com.z_company.route.viewmodel.home_view_model.ItemState
+import com.z_company.route.viewmodel.home_view_model.UpdateEvent
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -152,6 +153,8 @@ fun HomeScreen(
     homeRestValue: Long?,
     offsetInMoscow: Long,
     syncRoute: (Route) -> Unit,
+    updateEvent: SharedFlow<UpdateEvent>,
+    completeUpdateRequested: () -> Unit,
     setFavoriteState: (Route) -> Unit,
     dateAndTimeConverter: DateAndTimeConverter?,
     extendedServicePhaseTime: ResultState<Long>?,
@@ -210,6 +213,25 @@ fun HomeScreen(
     }
 
     val widthScreen = LocalConfiguration.current.screenWidthDp
+
+    LaunchedEffect(Unit) {
+        scope.launch {
+            updateEvent.flowWithLifecycle(lifecycle).collect { event ->
+                when (event) {
+                    UpdateEvent.UpdateCompleted -> {
+                        val result = snackbarHostState
+                            .showSnackbar(
+                                message = "Обновление загружено",
+                                actionLabel = "Установить"
+                            )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            completeUpdateRequested()
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     var isShowDialogConfirmRemoveRoute by remember { mutableStateOf(false) }
 

--- a/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
@@ -80,6 +80,12 @@ import java.util.TimeZone
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 
+import ru.rustore.sdk.appupdate.listener.InstallStateUpdateListener
+import ru.rustore.sdk.appupdate.manager.RuStoreAppUpdateManager
+import ru.rustore.sdk.appupdate.model.AppUpdateOptions
+import ru.rustore.sdk.appupdate.model.AppUpdateType
+import ru.rustore.sdk.appupdate.model.InstallStatus
+import ru.rustore.sdk.appupdate.model.UpdateAvailability
 data class OpenRouteFormEvent(val basicId: String?, val isMakeCopy: Boolean)
 
 class HomeViewModel(application: Application) : AndroidViewModel(application = application),
@@ -91,6 +97,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application = a
     private val salarySettingUseCase: SalarySettingUseCase by inject()
     private val sharedPreferenceStorage: SharedPreferencesRepositories by inject()
     private val routeHelper: RouteActionsHelper by inject()
+    private val ruStoreAppUpdateManager: RuStoreAppUpdateManager by inject()
     private val snackbarManager: ISnackbarManager by inject()
 
     var timeWithoutHoliday by mutableLongStateOf(0L)
@@ -133,12 +140,23 @@ class HomeViewModel(application: Application) : AndroidViewModel(application = a
     private val _previewRouteUiState = MutableStateFlow(PreviewRouteUiState())
     val previewRouteUiState = _previewRouteUiState.asStateFlow()
 
+    private val _updateEvents = MutableSharedFlow<UpdateEvent>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val updateEvents = _updateEvents.asSharedFlow()
+
     // month/year lists for pickers
     private val _monthList = MutableStateFlow<List<Int>>(emptyList())
     val monthList: StateFlow<List<Int>> = _monthList.asStateFlow()
 
     private val _yearList = MutableStateFlow<List<Int>>(emptyList())
     val yearList: StateFlow<List<Int>> = _yearList.asStateFlow()
+
+    override fun onCleared() {
+        super.onCleared()
+        ruStoreAppUpdateManager.unregisterListener(installStateUpdateListener)
+    }
 
     fun convertTimeToStringFormat(timeToLong: Long?): String {
         currentUserSetting?.let { settings ->
@@ -149,6 +167,52 @@ class HomeViewModel(application: Application) : AndroidViewModel(application = a
             }
         }
         return ConverterLongToTime.getTimeInStringFormat(timeToLong)
+    }
+
+    fun initUpdateManager() {
+        ruStoreAppUpdateManager.getAppUpdateInfo()
+            .addOnSuccessListener { appUpdateInfo ->
+                if (appUpdateInfo.updateAvailability == UpdateAvailability.Companion.UPDATE_AVAILABLE) {
+                    ruStoreAppUpdateManager.registerListener(installStateUpdateListener)
+                    ruStoreAppUpdateManager
+                        .startUpdateFlow(appUpdateInfo, AppUpdateOptions.Builder().build())
+                        .addOnSuccessListener { resultCode ->
+                            when (resultCode) {
+                                Activity.RESULT_CANCELED -> {}
+                                Activity.RESULT_OK -> {}
+                            }
+                        }
+                        .addOnFailureListener { throwable ->
+                            Log.e("ZZZ", "startUpdateFlow error", throwable)
+                        }
+                }
+            }
+            .addOnFailureListener { throwable ->
+                Log.e("ZZZ", "getAppUpdateInfo error", throwable)
+            }
+    }
+
+    private val installStateUpdateListener = InstallStateUpdateListener { installState ->
+        when (installState.installStatus) {
+            InstallStatus.Companion.DOWNLOADED -> {
+                _updateEvents.tryEmit(UpdateEvent.UpdateCompleted)
+            }
+            InstallStatus.Companion.DOWNLOADING -> {}
+            InstallStatus.Companion.FAILED -> {
+                Log.e("ZZZ", "Downloading error")
+            }
+        }
+    }
+
+    fun completeUpdateRequested() {
+        ruStoreAppUpdateManager.completeUpdate(
+            AppUpdateOptions.Builder().appUpdateType(
+                AppUpdateType.Companion.FLEXIBLE
+            ).build()
+        )
+            .addOnFailureListener { throwable ->
+                Log.e("ZZZ", "completeUpdate error", throwable)
+            }
     }
 
     fun setFavoriteRoute(route: Route) {

--- a/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/UpdateEvent.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/UpdateEvent.kt
@@ -1,0 +1,5 @@
+package com.z_company.route.viewmodel.home_view_model
+
+sealed class UpdateEvent {
+    object UpdateCompleted : UpdateEvent()
+}


### PR DESCRIPTION
- Restore RuStoreAppUpdateManager in HomeViewModel, HomeScreen, HomeDestination and re-create UpdateModule/UpdateEvent (were accidentally removed during Back4App/RuStorePay cleanup)
- Fix Android 16: UserSettings reset to defaults on every launch — setTokenIsFirstAppEntry(false) was never called; now called synchronously (commit) in MainViewModel.init{} before any async work
- Fix Android 16: WorkManager ANR — removed blocking .get() call on main thread in StartApp; ExistingPeriodicWorkPolicy.KEEP handles deduplication natively
- Use synchronous SharedPreferences commit() for isFirstAppEntry flag to survive process death on Android 16

https://claude.ai/code/session_015cfGpgSvncSCQ5gNRSW5eZ