### PR TITLE
feat: импорт/экспорт .zroute файлов через Telegram и другие мессенджеры

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,25 @@
                 <data android:scheme="z_company_loco_driver_scheme" />
             </intent-filter>
 
+            <!-- Открытие .zroute файлов с кастомным MIME (прямой шаринг из приложения) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content"
+                    android:mimeType="application/vnd.com.z_company.loco_driver.route" />
+                <data android:scheme="file"
+                    android:mimeType="application/vnd.com.z_company.loco_driver.route" />
+            </intent-filter>
+
+            <!-- Открытие .zroute файлов через Telegram и другие мессенджеры (отправляют как octet-stream) -->
+            <!-- MainActivity проверяет расширение файла через ContentResolver.DISPLAY_NAME -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" android:mimeType="application/octet-stream" />
+                <data android:scheme="file" android:mimeType="application/octet-stream" />
+            </intent-filter>
+
         </activity>
 
 

--- a/app/src/main/java/com/z_company/loco_driver/MainActivity.kt
+++ b/app/src/main/java/com/z_company/loco_driver/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.provider.OpenableColumns
 import android.util.Log
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
@@ -12,9 +13,12 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.robokassa.library.helper.toParams
 import com.robokassa.library.pay.RobokassaPayLauncher
+import com.z_company.RouteSerializer
 import com.z_company.loco_driver.ui.LocoDriverApp
 import com.z_company.loco_driver.ui.rememberLocoDriverAppState
 import com.z_company.loco_driver.viewmodel.MainViewModel
@@ -44,9 +48,13 @@ class MainActivity : ComponentActivity(), KoinComponent {
 
         setContent {
             val appState = rememberLocoDriverAppState()
+            val pendingImportRoute by mainViewModel.pendingImportRoute.collectAsState()
             LocoDriverApp(
                 appState = appState,
-                isShowUpdatePresentation = mainViewModel.showUpdatePresentation
+                isShowUpdatePresentation = mainViewModel.showUpdatePresentation,
+                pendingImportRoute = pendingImportRoute,
+                onConfirmImport = mainViewModel::confirmImportRoute,
+                onDismissImport = mainViewModel::dismissImportRoute
             )
         }
         VKID.logsEnabled = true
@@ -65,6 +73,37 @@ class MainActivity : ComponentActivity(), KoinComponent {
             }
         }
 
+        // Импорт .zroute файла
+        if (i?.action == Intent.ACTION_VIEW && data != null) {
+            val mimeType = i.type ?: contentResolver.getType(data)
+            val isCustomMime = mimeType == "application/vnd.com.z_company.loco_driver.route"
+            val isOctetStream = mimeType == "application/octet-stream"
+            if (isCustomMime || (isOctetStream && isZrouteFile(data))) {
+                importRouteFrom(data)
+            }
+        }
+    }
+
+    private fun isZrouteFile(uri: Uri): Boolean {
+        return try {
+            val cursor = contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            cursor?.use {
+                if (it.moveToFirst()) it.getString(0).endsWith(".zroute", ignoreCase = true)
+                else false
+            } ?: uri.lastPathSegment?.endsWith(".zroute", ignoreCase = true) ?: false
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun importRouteFrom(uri: Uri) {
+        try {
+            val json = contentResolver.openInputStream(uri)?.bufferedReader()?.readText() ?: return
+            val route = RouteSerializer.deserialize(json)
+            mainViewModel.setPendingImportRoute(route)
+        } catch (e: Exception) {
+            Log.e("ImportRoute", "Ошибка чтения .zroute файла", e)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/z_company/loco_driver/ui/LocoDriverApp.kt
+++ b/app/src/main/java/com/z_company/loco_driver/ui/LocoDriverApp.kt
@@ -10,13 +10,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import com.z_company.core.ui.theme.Shapes
+import com.z_company.core.ui.theme.custom.AppTypography
+import com.z_company.domain.entities.route.Route
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.luminance // Изменено: Добавлен импорт для luminance() — это метод Color, чтобы вычислить яркость цвета (0..1).
@@ -49,7 +56,10 @@ import androidx.compose.foundation.layout.systemBars // Изменено: Доб
 @Composable
 fun LocoDriverApp(
     appState: LocoDriverAppState,
-    isShowUpdatePresentation: Boolean
+    isShowUpdatePresentation: Boolean,
+    pendingImportRoute: Route? = null,
+    onConfirmImport: () -> Unit = {},
+    onDismissImport: () -> Unit = {}
 ) {
     LocoDriverTheme {
         val navController = rememberNavController()
@@ -136,6 +146,39 @@ fun LocoDriverApp(
             // Презентация обновления — поверх всего
             if (isShowUpdatePresentation) {
                 UpdatePresentationBlockDestination(router = appState.router)
+            }
+
+            // Диалог импорта маршрута из .zroute файла
+            if (pendingImportRoute != null) {
+                AlertDialog(
+                    onDismissRequest = onDismissImport,
+                    shape = Shapes.medium,
+                    title = {
+                        Text(text = "Импорт маршрута", style = AppTypography.getType().headlineSmall)
+                    },
+                    text = {
+                        Text(
+                            text = "Импортировать маршрут от ${pendingImportRoute.basicData.timeStartWork?.let {
+                                java.text.SimpleDateFormat("dd.MM.yyyy", java.util.Locale.getDefault()).format(java.util.Date(it))
+                            } ?: "неизвестной даты"}?",
+                            style = AppTypography.getType().bodyLarge
+                        )
+                    },
+                    confirmButton = {
+                        Button(shape = Shapes.medium, onClick = onConfirmImport) {
+                            Text(text = "Импортировать", style = AppTypography.getType().titleMedium)
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = onDismissImport) {
+                            Text(
+                                text = "Отмена",
+                                style = AppTypography.getType().titleMedium,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/z_company/loco_driver/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/z_company/loco_driver/viewmodel/MainViewModel.kt
@@ -6,11 +6,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.robokassa.library.params.PaymentParams
 import com.z_company.core.ResultState
+import com.z_company.core.ui.snackbar.ISnackbarManager
 import com.z_company.domain.entities.Day
 import com.z_company.domain.entities.MonthOfYear
+import com.z_company.domain.entities.route.Route
 import com.z_company.domain.repositories.SharedPreferencesRepositories
 import com.z_company.domain.use_cases.LoadCalendarFromStorage
 import com.z_company.domain.use_cases.CalendarUseCase
+import com.z_company.domain.use_cases.RouteUseCase
 import com.z_company.domain.use_cases.SalarySettingUseCase
 import com.z_company.domain.use_cases.SettingsUseCase
 import com.z_company.route.viewmodel.PurchasesViewModel
@@ -38,6 +41,8 @@ class MainViewModel : ViewModel(), KoinComponent, DefaultLifecycleObserver {
     private val calendarUseCase: CalendarUseCase by inject()
     private val settingsUseCase: SettingsUseCase by inject()
     private val sharedPreferenceStorage: SharedPreferencesRepositories by inject()
+    private val routeUseCase: RouteUseCase by inject()
+    private val snackbarManager: ISnackbarManager by inject()
 
     private var saveCalendarInLocalJob: Job? = null
     private var setDefaultSetting: Job? = null
@@ -50,6 +55,32 @@ class MainViewModel : ViewModel(), KoinComponent, DefaultLifecycleObserver {
 
     private val _appInitialized = MutableStateFlow(false)
     val appInitialized: StateFlow<Boolean> = _appInitialized.asStateFlow()
+
+    // Импорт маршрута из файла (.zroute) — ожидает подтверждения пользователя
+    private val _pendingImportRoute = MutableStateFlow<Route?>(null)
+    val pendingImportRoute: StateFlow<Route?> = _pendingImportRoute.asStateFlow()
+
+    fun setPendingImportRoute(route: Route) {
+        _pendingImportRoute.value = route
+    }
+
+    fun confirmImportRoute() {
+        val route = _pendingImportRoute.value ?: return
+        _pendingImportRoute.value = null
+        viewModelScope.launch {
+            routeUseCase.saveRoute(route).collect { result ->
+                when (result) {
+                    is ResultState.Success -> snackbarManager.show("Маршрут импортирован")
+                    is ResultState.Error -> snackbarManager.show("Ошибка импорта маршрута")
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    fun dismissImportRoute() {
+        _pendingImportRoute.value = null
+    }
 
     init {
         if (isFirstEntry) {

--- a/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
@@ -28,7 +28,7 @@ import com.z_company.domain.entities.route.UtilsForEntities.isHolidayTimeInRoute
 import com.z_company.domain.entities.route.UtilsForEntities.timeFollowingSingleLocomotive
 import com.z_company.domain.repositories.SharedPreferencesRepositories
 import com.z_company.domain.use_cases.CalendarUseCase
-import com.z_company.repository.SecureDataStore
+import com.z_company.repository.SecureTokenStorage
 import com.z_company.repository.remote_rest.RoutesManager
 import com.z_company.route.viewmodel.PreviewRouteUiState
 import com.z_company.route.viewmodel.RouteActionsHelper
@@ -86,6 +86,8 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
     private val subscriptionHelper: SubscriptionHelper by inject()
     private val sharedPreferenceStorage: SharedPreferencesRepositories by inject()
     private val snackbarManager: ISnackbarManager by inject()
+    private val secureTokenStorage: SecureTokenStorage by inject()
+    private val routesManager: RoutesManager by inject()
 
     private var removeRouteJob: Job? = null
 
@@ -235,7 +237,11 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
 
                 // Intent для шаринга (без изменений)
                 val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                    type = "application/vnd.com.z_company.loco_driver.route"
+                    // application/octet-stream используется намеренно:
+                    // кастомный MIME-тип игнорируется мессенджерами (Telegram и др.) при пересылке.
+                    // Получатель открывает файл через intent-filter в AndroidManifest, где
+                    // MainActivity проверяет расширение .zroute через ContentResolver.DISPLAY_NAME.
+                    type = "application/octet-stream"
                     putExtra(Intent.EXTRA_STREAM, uri)
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
@@ -266,7 +272,7 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
 
     fun restorePurchases() {
         viewModelScope.launch(Dispatchers.IO) {
-            val token = SecureDataStore.getAuthBearerTokenFlow(application).first()
+            val token = secureTokenStorage.getAuthBearerTokenFlow().first()
             subscriptionHelper.restorePurchases(snackbarManager, token)
         }
     }
@@ -300,9 +306,8 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun syncRoute(route: Route) {
-        val routesManager = RoutesManager
         viewModelScope.launch {
-            val token = SecureDataStore.getAuthBearerTokenFlow(application).first()
+            val token = secureTokenStorage.getAuthBearerTokenFlow().first()
             val fullToken = "Bearer $token"
             if (token == null) {
                 snackbarManager.show(message = "Неавторизованный пользователь")


### PR DESCRIPTION
Проблема: при пересылке через Telegram кастомный MIME-тип терялся, получатель видел браузеры вместо LocoDriver.

Решение:
- AndroidManifest: добавлены intent-filter для .zroute файлов (application/vnd.com.z_company.loco_driver.route и application/octet-stream)
- AllRouteViewModel.shareRoute: MIME-тип изменён на application/octet-stream (кастомный игнорируется мессенджерами при пересылке)
- AllRouteViewModel: убраны SecureDataStore + RoutesManager object, добавлена инжекция SecureTokenStorage и RoutesManager
- MainActivity: обработка входящего .zroute файла: проверка DISPLAY_NAME через ContentResolver, чтение и десериализация
- MainViewModel: состояние pendingImportRoute + confirmImportRoute/dismissImportRoute через RouteUseCase.saveRoute
- LocoDriverApp: диалог подтверждения импорта маршрута

https://claude.ai/code/session_015cfGpgSvncSCQ5gNRSW5eZ