### PR TITLE
fix: обновить Koin до 4.1.1, serialization до 1.9.0, исправить Secure…

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -97,7 +97,7 @@ object Versions {
     const val room_version = "2.7.1"
     const val test_ext_version = "1.1.5"
     const val test_runner_version = "1.6.0-alpha01"
-    const val koin_version = "3.5.6"
+    const val koin_version = "4.1.1"
     const val accompanist_pager_version = "0.34.0"
     const val gson_version = "2.11.0"
     const val constraint_layout_ver = "1.0.1"
@@ -127,7 +127,7 @@ object Versions {
 
     const val datastore_preferences_ver = "1.2.0"
     const val crypto_tink_ver = "1.7.0"
-    const val kotlin_x_serialization_json_ver = "1.10.0"
+    const val kotlin_x_serialization_json_ver = "1.9.0"
     const val ktor_ver = "3.0.3"
     const val sqldelight_ver = "2.0.2"
     // Compose Multiplatform (совместим с Kotlin 2.2.0)

--- a/data_remote/src/iosMain/kotlin/com/z_company/repository/SecureTokenStorage.kt
+++ b/data_remote/src/iosMain/kotlin/com/z_company/repository/SecureTokenStorage.kt
@@ -1,7 +1,8 @@
-@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
 
 package com.z_company.repository
 
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
@@ -9,12 +10,13 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import platform.CoreFoundation.CFTypeRefVar
 import platform.Foundation.NSMutableDictionary
 import platform.Foundation.NSNumber
 import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
-import platform.Security.CFTypeRefVar
+import platform.Foundation.dataUsingEncoding
 import platform.Security.SecItemAdd
 import platform.Security.SecItemCopyMatching
 import platform.Security.SecItemDelete
@@ -49,6 +51,7 @@ actual class SecureTokenStorage {
 
     /** Сохраняет строку в Keychain. Удаляет старую запись перед добавлением. */
     private fun saveSecure(key: String, value: String) {
+        @Suppress("CAST_NEVER_SUCCEEDS")
         val data = (value as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return
 
         // Удаляем существующую запись


### PR DESCRIPTION
…TokenStorage iOS

- koin_version 3.5.6 → 4.1.1 (koin-compose с iOS поддержкой только в 4.x)
- kotlinx-serialization-json 1.10.0 → 1.9.0 (совместим с Kotlin 2.2.0)
- SecureTokenStorage: CFTypeRefVar импорт из CoreFoundation, добавлен BetaInteropApi opt-in