### PR TITLE
fix: удалить ru.ok.tracer, исправить дублирование routesManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     id(Plugins.android_app)
     id(Plugins.kotlin_android)
     id(Plugins.ksp)
-    id("ru.ok.tracer").version(Versions.ru_ok_tracer_platform_ver)
     id(Plugins.compose_compiler)
     id(Plugins.vkIdManifest)
     id("org.jetbrains.kotlin.plugin.serialization")
@@ -99,13 +98,6 @@ kotlin {
     }
 }
 
-tracer {
-    create("defaultConfig") {
-        pluginToken = "fXDqsEd0kMKfFaGKjIOyiNSkthd3jXtkvvvP1Ckevvf0"
-        appToken = "1io5grTlupk1xA2hlnGu4uthwGqLCge4HE5xHMfTgYH0"
-    }
-}
-
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
@@ -114,10 +106,7 @@ dependencies {
     implementation(Libs.mytracker_sdk)
     implementation(platform(Libs.rustore_bom))
     implementation(Libs.rustore_sdk_appupdate)
-
-    implementation(platform(Libs.ru_ok_tracer_platform))
-    implementation(Libs.ru_ok_tracer_tracer_crash_report)
-    implementation(Libs.ru_ok_tracer_tracer_heap_dumps)
+    implementation(Libs.work_manager)
 
     implementation(project(Libs.project_core_android))
     implementation(project(Libs.project_domain))

--- a/data_remote/build.gradle.kts
+++ b/data_remote/build.gradle.kts
@@ -45,9 +45,6 @@ kotlin {
             // Android-specific
             implementation(Libs.oneTapVkId)
             implementation(Libs.vkId)
-            implementation(Libs.rustore_review)
-            implementation(Libs.ru_ok_tracer_platform)
-            implementation(Libs.ru_ok_tracer_tracer_crash_report)
             implementation(Libs.core_ktx)
             implementation(Libs.app_compat)
             implementation(Libs.compose_material3)

--- a/features/route/build.gradle.kts
+++ b/features/route/build.gradle.kts
@@ -57,9 +57,6 @@ dependencies {
     implementation(project(Libs.project_data_remote))
     implementation(project(Libs.project_robokassa_sdk))
 
-    implementation(platform(Libs.ru_ok_tracer_platform))
-    implementation(Libs.ru_ok_tracer_tracer_crash_report)
-
 //    implementation(Libs.lifecycle_runtime_compose)
     implementation(Libs.activity_compose)
     implementation(Libs.core_ktx)

--- a/features/route/src/main/java/com/z_company/route/viewmodel/ProfileViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/ProfileViewModel.kt
@@ -54,9 +54,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
-import java.io.NotActiveException
 import java.util.Calendar
-import ru.ok.tracer.crash.report.TracerCrashReport
 
 data class ProfileUiState(
     val userDetailsState: ResultState<UserRemote?> = ResultState.Loading(),
@@ -817,7 +815,7 @@ class ProfileViewModel : ViewModel(), KoinComponent {
                                                 "Migration",
                                                 "Ошибка сохранения маршрута ${route.basicData.id}: ${saveResult.entity.message}"
                                             )
-                                            TracerCrashReport.report(NotActiveException("migration \nsave route \nuser bearer token \n$token \nuserId $userId error \n${saveResult.entity} \n${route.basicData.id}\n $route"))
+                                            Log.e("Migration","migration \nsave route \nuser bearer token \n$token \nuserId $userId error \n${saveResult.entity} \n${route.basicData.id}\n $route")
                                             // Продолжаем с остальными, но отметим ошибку
                                         }
 
@@ -847,7 +845,7 @@ class ProfileViewModel : ViewModel(), KoinComponent {
                                 .first { it is ResultState.Success || it is ResultState.Error }
 
                             if (saveSubscribeTimeInLocal is ResultState.Error) {
-                                TracerCrashReport.report(NotActiveException("migration \n save salarySetting \nuser bearer token \n userId $userId \n$token \n при миграции не перенесены данные подписки в UserSetting"))
+                                Log.e("Migration","migration \n save salarySetting \nuser bearer token \n userId $userId \n$token \n при миграции не перенесены данные подписки в UserSetting")
                             }
 
                             settingManager.saveUserSettingInRemote(l, fullToken)
@@ -859,7 +857,7 @@ class ProfileViewModel : ViewModel(), KoinComponent {
 
                                         is ResultState.Error -> {
                                             hasSettingsError = true
-                                            TracerCrashReport.report(NotActiveException("migration  \nsave userSetting \n userId $userId \nuser bearer token \n$token\n ${saveState.entity} \n $localUserSettings"))
+                                            Log.e("Migration","migration  \nsave userSetting \n userId $userId \nuser bearer token \n$token\n ${saveState.entity} \n $localUserSettings")
                                             // Продолжаем к следующей настройке
                                         }
 
@@ -879,7 +877,7 @@ class ProfileViewModel : ViewModel(), KoinComponent {
 
                                         is ResultState.Error -> {
                                             hasSettingsError = true
-                                            TracerCrashReport.report(NotActiveException("migration  \nsave salarySetting \n userId $userId \nuser bearer token \n$token \n${saveState.entity} \n $localSalarySetting"))
+                                            Log.e("Migration","migration  \nsave salarySetting \n userId $userId \nuser bearer token \n$token \n${saveState.entity} \n $localSalarySetting")
 
                                         }
 
@@ -902,7 +900,7 @@ class ProfileViewModel : ViewModel(), KoinComponent {
                                                 "Migration",
                                                 "Ошибка сохранения MonthOfYearList: ${saveState.entity.message}"
                                             )
-                                            TracerCrashReport.report(NotActiveException("migration  \nsave MonthOfYearList \n userId $userId \nuser bearer token \n$token ${saveState.entity} \n $localMonths"))
+                                            Log.e("Migration","migration  \nsave MonthOfYearList \n userId $userId \nuser bearer token \n$token ${saveState.entity} \n $localMonths")
 
                                         }
 

--- a/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
@@ -89,8 +89,6 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
     private val secureTokenStorage: SecureTokenStorage by inject()
     private val routesManager: RoutesManager by inject()
 
-    private val routesManager: RoutesManager by inject()
-
     private var removeRouteJob: Job? = null
 
     private val _uiState = MutableStateFlow(RoutesUiState())


### PR DESCRIPTION
- Удалён плагин ru.ok.tracer и зависимости tracer из app, data_remote, features/route
- TracerCrashReport.report() заменён на Log.e() в ProfileViewModel
- Убрано дублирование routesManager в AllRouteViewModel
- Убрана неуправляемая rustore_review из data_remote (не используется)
- Добавлена work_manager зависимость в app (требуется StartApp)