### PR TITLE
fix: обработка downgrade Room→SQLDelight в DatabaseDriverFactory

### DIFF
--- a/data_local/src/androidMain/kotlin/com/z_company/data_local/DatabaseDriverFactory.kt
+++ b/data_local/src/androidMain/kotlin/com/z_company/data_local/DatabaseDriverFactory.kt
@@ -1,7 +1,10 @@
 package com.z_company.data_local
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.z_company.data_local.route.db.RouteDatabase
 import com.z_company.data_local.route.searchdb.SearchResponseDatabase
@@ -10,14 +13,34 @@ import com.z_company.data_local.setting.salarydb.SalarySettingDatabase
 
 actual class DatabaseDriverFactory(private val context: Context) {
     actual fun createRouteDriver(): SqlDriver =
-        AndroidSqliteDriver(RouteDatabase.Schema, context, "Route.db")
+        createDriver(RouteDatabase.Schema, "Route.db")
 
     actual fun createSettingsDriver(): SqlDriver =
-        AndroidSqliteDriver(SettingsDatabase.Schema, context, "Settings.db")
+        createDriver(SettingsDatabase.Schema, "Settings.db")
 
     actual fun createSalarySettingDriver(): SqlDriver =
-        AndroidSqliteDriver(SalarySettingDatabase.Schema, context, "SalarySetting.db")
+        createDriver(SalarySettingDatabase.Schema, "SalarySetting.db")
 
     actual fun createSearchResponseDriver(): SqlDriver =
-        AndroidSqliteDriver(SearchResponseDatabase.Schema, context, "SearchResponse.db")
+        createDriver(SearchResponseDatabase.Schema, "SearchResponse.db")
+
+    /**
+     * Создаёт драйвер с поддержкой downgrade из старой Room БД.
+     * Room использовал version 14+, SQLDelight начинает с version 1.
+     * При downgrade просто сбрасываем version — таблицы совместимы.
+     */
+    private fun createDriver(
+        schema: SqlSchema<QueryResult.Value<Unit>>,
+        name: String
+    ): SqlDriver = AndroidSqliteDriver(
+        schema = schema,
+        context = context,
+        name = name,
+        callback = object : AndroidSqliteDriver.Callback(schema) {
+            override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
+                // Room version > SQLDelight version — допускаем downgrade без потери данных.
+                // Таблицы структурно совместимы после миграции Step 9.
+            }
+        }
+    )
 }


### PR DESCRIPTION
Room использовал version 14, SQLDelight начинает с version 1. Добавлен custom Callback с onDowngrade, чтобы избежать SQLiteException: Can't downgrade database from version 14 to 1.