### PR TITLE
fix: исправить отображение маршрутов — ReleaseType совместимость с Gs…

### DIFF
--- a/data_local/src/androidMain/kotlin/com/z_company/data_local/DatabaseDriverFactory.kt
+++ b/data_local/src/androidMain/kotlin/com/z_company/data_local/DatabaseDriverFactory.kt
@@ -24,11 +24,6 @@ actual class DatabaseDriverFactory(private val context: Context) {
     actual fun createSearchResponseDriver(): SqlDriver =
         createDriver(SearchResponseDatabase.Schema, "SearchResponse.db")
 
-    /**
-     * Создаёт драйвер с поддержкой downgrade из старой Room БД.
-     * Room использовал version 14+, SQLDelight начинает с version 1.
-     * При downgrade просто сбрасываем version — таблицы совместимы.
-     */
     private fun createDriver(
         schema: SqlSchema<QueryResult.Value<Unit>>,
         name: String
@@ -38,8 +33,8 @@ actual class DatabaseDriverFactory(private val context: Context) {
         name = name,
         callback = object : AndroidSqliteDriver.Callback(schema) {
             override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-                // Room version > SQLDelight version — допускаем downgrade без потери данных.
-                // Таблицы структурно совместимы после миграции Step 9.
+                // Room использовал version 14+, SQLDelight начинает с version 1.
+                // При downgrade просто пропускаем — таблицы совместимы.
             }
         }
     )

--- a/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/BasicData.sq
+++ b/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/BasicData.sq
@@ -30,8 +30,13 @@ SELECT * FROM BasicData;
 
 getByPeriod:
 SELECT * FROM BasicData
-WHERE (timeStartWork <= :endPeriod AND timeEndWork >= :startPeriod AND isDeleted = 0)
-   OR (timeStartWork BETWEEN :startPeriod AND :endPeriod AND isDeleted = 0)
+WHERE isDeleted = 0
+  AND (
+    (timeStartWork >= :startPeriod AND timeStartWork <= :endPeriod)
+    OR (timeEndWork >= :startPeriod AND timeEndWork <= :endPeriod)
+    OR (timeStartWork <= :startPeriod AND timeEndWork >= :endPeriod)
+    OR (timeStartWork <= :endPeriod AND timeEndWork IS NULL)
+  )
 ORDER BY timeStartWork DESC;
 
 delete:

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/MonthOfYear.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/MonthOfYear.kt
@@ -11,6 +11,10 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.datetime.LocalDate
 
 @Serializable
@@ -39,6 +43,10 @@ data class ReleasePeriod(
  * Кастомный сериализатор для sealed class ReleaseType.
  * Заменяет Gson TypeAdapter (ReleaseTypeAdapter).
  * Сериализует как строку — значение поля text.
+ *
+ * Десериализация поддерживает два формата:
+ * - Новый (kotlinx.serialization): примитивная строка "Отпуск"
+ * - Старый (Gson/Room): JSON-объект {"type":"Vacation"}
  */
 object ReleaseTypeSerializer : KSerializer<ReleaseType> {
     override val descriptor: SerialDescriptor =
@@ -49,14 +57,36 @@ object ReleaseTypeSerializer : KSerializer<ReleaseType> {
     }
 
     override fun deserialize(decoder: Decoder): ReleaseType {
-        return when (decoder.decodeString()) {
-            "Донорские" -> ReleaseType.Donor
-            "Курсы" -> ReleaseType.Courses
-            "Больничный" -> ReleaseType.SickLeave
-            "Отпуск" -> ReleaseType.Vacation
-            "По уходу за ребенком-инвалидом" -> ReleaseType.ChildCare
-            else -> ReleaseType.Other
+        // Поддержка legacy Gson-формата {"type":"Vacation"} из старой Room БД
+        if (decoder is JsonDecoder) {
+            return when (val element = decoder.decodeJsonElement()) {
+                is JsonPrimitive -> fromText(element.content)
+                is JsonObject -> fromGsonType(element["type"]?.jsonPrimitive?.content)
+                else -> ReleaseType.Other
+            }
         }
+        // Fallback для не-JSON декодеров
+        return fromText(decoder.decodeString())
+    }
+
+    /** Маппинг по русскому тексту (новый формат kotlinx.serialization) */
+    private fun fromText(text: String): ReleaseType = when (text) {
+        "Донорские" -> ReleaseType.Donor
+        "Курсы" -> ReleaseType.Courses
+        "Больничный" -> ReleaseType.SickLeave
+        "Отпуск" -> ReleaseType.Vacation
+        "По уходу за ребенком-инвалидом" -> ReleaseType.ChildCare
+        else -> ReleaseType.Other
+    }
+
+    /** Маппинг по английскому имени класса (legacy Gson-формат из Room) */
+    private fun fromGsonType(type: String?): ReleaseType = when (type) {
+        "Vacation" -> ReleaseType.Vacation
+        "SickLeave" -> ReleaseType.SickLeave
+        "Courses" -> ReleaseType.Courses
+        "Donor" -> ReleaseType.Donor
+        "ChildCare" -> ReleaseType.ChildCare
+        else -> ReleaseType.Other
     }
 }
 

--- a/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
@@ -866,15 +866,10 @@ class HomeViewModel : ViewModel(), KoinComponent {
             routesFlow.collect { result ->
                 when (result) {
                     is ResultState.Loading -> {
-                        // optional: reflect loading state in UI if you want
-                        // we update UI on Main thread
-//                        withContext(Dispatchers.Main) {
                         _uiState.update { it.copy(listItemState = mutableListOf()) }
-//                        }
                     }
 
                     is ResultState.Success -> {
-                        // all further processing must run on IO or Default depending on heavy computations
                         val fullRouteList = result.data
                         val userSettings = currentUserSetting
                         val salarySetting = currentSalarySetting


### PR DESCRIPTION
…on и getByPeriod с NULL timeEndWork

Корневая причина: ReleaseTypeSerializer ожидал строку "Отпуск", но в Room БД хранился Gson-формат {"type":"Vacation"}. Десериализация MonthOfYear падала, fallback возвращал текущий месяц → getByPeriod не находил маршруты.

- ReleaseTypeSerializer: поддержка обоих форматов через JsonDecoder
- getByPeriod: корректная обработка NULL timeEndWork (незавершённые маршруты)
- Убрано диагностическое логирование из 5 файлов