### PR TITLE
fix: устранить моргание Loading в AllRouteScreen

### DIFF
--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/SqlDelightRouteRepository.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/SqlDelightRouteRepository.kt
@@ -139,9 +139,8 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
     }
 
     override fun loadRoutesByPeriod(startPeriod: Long, endPeriod: Long): Flow<ResultState<List<Route>>> {
-        return flowMap {
-            loadRouteByPeriodFlow(startPeriod, endPeriod).map { ResultState.Success(it) }
-        }
+        return loadRouteByPeriodFlow(startPeriod, endPeriod)
+            .map<List<Route>, ResultState<List<Route>>> { ResultState.Success(it) }
     }
 
     override fun loadRoutesAsStateFlow(): Flow<ResultState<List<Route>>> {

--- a/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
@@ -55,34 +57,20 @@ class RouteUseCase(private val repository: RouteRepository) {
     fun listRoutesByMonth(
         monthOfYear: MonthOfYear,
         offsetInMoscow: Long
-    ): Flow<ResultState<List<Route>>> =
-        channelFlow {
-            trySend(ResultState.Loading())
+    ): Flow<ResultState<List<Route>>> = flow {
+        emit(ResultState.Loading())
 
-            val tz = TimeZone.currentSystemDefault()
-            val startDate = LocalDate(monthOfYear.year, monthOfYear.month + 1, 1)
-            val startMonthInLong = startDate.atStartOfDayIn(tz).toEpochMilliseconds() - offsetInMoscow
-            val maxDayOfMonth = startDate.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY).dayOfMonth
+        val tz = TimeZone.currentSystemDefault()
+        val startDate = LocalDate(monthOfYear.year, monthOfYear.month + 1, 1)
+        val startMonthInLong = startDate.atStartOfDayIn(tz).toEpochMilliseconds() - offsetInMoscow
+        val maxDayOfMonth = startDate.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY).dayOfMonth
 
-            val endMonthInLong = LocalDateTime(
-                monthOfYear.year, monthOfYear.month + 1, maxDayOfMonth, 23, 59, 0, 0
-            ).toInstant(tz).toEpochMilliseconds() - offsetInMoscow
+        val endMonthInLong = LocalDateTime(
+            monthOfYear.year, monthOfYear.month + 1, maxDayOfMonth, 23, 59, 0, 0
+        ).toInstant(tz).toEpochMilliseconds() - offsetInMoscow
 
-            withContext(Dispatchers.Default) {
-                this.launch {
-                    repository.loadRoutesByPeriod(startMonthInLong, endMonthInLong)
-                        .collect { result ->
-                            if (result is ResultState.Success) {
-                                trySend(ResultState.Success(result.data))
-                            }
-                            if (result is ResultState.Error) {
-                                trySend(ResultState.Error(ErrorEntity(result.entity.throwable)))
-                            }
-                        }
-                }
-            }
-            awaitClose()
-        }
+        emitAll(repository.loadRoutesByPeriod(startMonthInLong, endMonthInLong))
+    }
 
     fun listRouteWithDeleting(): List<Route> {
         return repository.loadRoutesWithDeleting()

--- a/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
@@ -90,6 +90,7 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
     private val routesManager: RoutesManager by inject()
 
     private var removeRouteJob: Job? = null
+    private var loadRoutesJob: Job? = null
 
     private val _uiState = MutableStateFlow(RoutesUiState())
     val uiState: StateFlow<RoutesUiState> = _uiState.asStateFlow()
@@ -144,7 +145,7 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
                 }
         }
 
-        // combinedData — поток настроек и salary (без stateIn, можно оставить stateIn если нужно)
+        // combinedData — поток настроек и salary
         val combinedData: Flow<LoadSettingData> = combine(
             salarySettingUseCase.salarySettingFlow().map { it as SalarySetting? }
                 .onStart { emit(null) },
@@ -154,16 +155,9 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
             LoadSettingData(ss, us)
         }
 
-        // 1) объединяем combinedData с latestRawRoutes и выбранными фильтрами
+        // Поток 1: реагирует на изменение настроек → загружает маршруты
         viewModelScope.launch {
-            combine(
-                combinedData,
-                latestRawRoutes,
-                _uiState.map { it.selectedFilters }.distinctUntilChanged()
-            ) { initData, rawRoutes, filters ->
-                Triple(initData, rawRoutes, filters)
-            }.collectLatest { (initData, rawRoutes, filters) ->
-                // если настройки ещё не готовы — можно очистить или выставить загрузку
+            combinedData.collectLatest { initData ->
                 userSettings = initData.userSettings
                 salarySetting = initData.salarySetting
                 val user = initData.userSettings
@@ -178,17 +172,28 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
                     return@collectLatest
                 }
 
-                // конвертер и т.п.
                 dateAndTimeConverter = DateAndTimeConverter(user)
-                val currentMonth = initData.userSettings.selectMonthOfYear
                 minTimeRest = user.minTimeRestPointOfTurnover
                 minTimeHomeRest = user.minTimeHomeRest
 
-                loadRoutes(user)
-                // строим состояния маршрутов (ItemState) — если rawRoutes уже в нужном виде, можно использовать их напрямую
-                val routeStateList = rawRoutes // если latestRawRoutes хранит ItemState
-                // применяем фильтры
-                val filtered = applyFilters(routeStateList, filters, salarySetting = salary)
+                // Отменяем предыдущую загрузку, запускаем новую
+                loadRoutesJob?.cancel()
+                loadRoutesJob = loadRoutes(user)
+            }
+        }
+
+        // Поток 2: реагирует на latestRawRoutes и фильтры → применяет фильтрацию (без loadRoutes!)
+        viewModelScope.launch {
+            combine(
+                latestRawRoutes,
+                _uiState.map { it.selectedFilters }.distinctUntilChanged()
+            ) { rawRoutes, filters ->
+                rawRoutes to filters
+            }.collectLatest { (rawRoutes, filters) ->
+                val salary = salarySetting ?: return@collectLatest
+                val user = userSettings ?: return@collectLatest
+
+                val filtered = applyFilters(rawRoutes, filters, salarySetting = salary)
                 val savedSort =
                     sharedPreferenceStorage.getSortOption()?.let { SortOption.valueOf(it) }
                         ?: SortOption.DATE_DESC
@@ -200,7 +205,7 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
                     it.copy(
                         filteredRoutes = filtered,
                         isLoading = false,
-                        currentMonthOfYear = currentMonth,
+                        currentMonthOfYear = user.selectMonthOfYear,
                         sortOption = savedSort,
                         selectedFilters = savedFilters,
                         isExpandedView = savedExpanded
@@ -410,14 +415,13 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    fun loadRoutes(userSettings: UserSettings) {
-        viewModelScope.launch(Dispatchers.IO) {
+    fun loadRoutes(userSettings: UserSettings): Job {
+        return viewModelScope.launch(Dispatchers.IO) {
             routeUseCase.listRoutesByMonth(userSettings.selectMonthOfYear, userSettings.timeZone)
-                .onStart { _uiState.update { it.copy(isLoading = true, errorMessage = null) } }
                 .collect { result ->
                     when (result) {
                         is ResultState.Loading -> {
-                            _uiState.update { it.copy(isLoading = true) }
+                            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
                         }
 
                         is ResultState.Success -> {
@@ -463,7 +467,6 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
                                     errorMessage = message
                                 )
                             }
-                            // показываем snackbar централизованно
                             snackbarManager.show(message = message)
                         }
                     }
@@ -500,7 +503,8 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
 
     fun reload() {
         userSettings?.let { setting ->
-            loadRoutes(setting)
+            loadRoutesJob?.cancel()
+            loadRoutesJob = loadRoutes(setting)
         }
     }
 

--- a/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
@@ -866,7 +866,7 @@ class HomeViewModel : ViewModel(), KoinComponent {
             routesFlow.collect { result ->
                 when (result) {
                     is ResultState.Loading -> {
-                        _uiState.update { it.copy(listItemState = mutableListOf()) }
+                        // Не очищаем список — показываем старые данные, пока загружаются новые
                     }
 
                     is ResultState.Success -> {


### PR DESCRIPTION
Корневая причина: feedback loop в AllRouteViewModel.init — combine включал latestRawRoutes, а loadRoutes() обновлял latestRawRoutes → бесконечный цикл. Дополнительно: двойной Loading от flowMap в loadRoutesByPeriod.

- AllRouteViewModel: разделить combine на два потока — загрузка (по настройкам) и фильтрация (по latestRawRoutes + фильтры), трекать loadRoutesJob
- SqlDelightRouteRepository: убрать flowMap из loadRoutesByPeriod — репозиторий не должен эмитить Loading для реактивного потока
- RouteUseCase: упростить listRoutesByMonth — flow + emitAll вместо channelFlow
- HomeViewModel: не очищать listItemState при Loading