### PR TITLE
fix: исправить несохранение станций в FormTrain — encodeDefaults + St…

### DIFF
--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/LocomotiveMapper.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/LocomotiveMapper.kt
@@ -8,7 +8,7 @@ import com.z_company.domain.entities.route.SectionElectric
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+private val json = Json { ignoreUnknownKeys = true; isLenient = true; encodeDefaults = true }
 
 internal object LocomotiveMapper {
 
@@ -19,10 +19,16 @@ internal object LocomotiveMapper {
         json.encodeToString(list)
 
     private fun decodeElectricSections(value: String): List<SectionElectric> =
-        runCatching { json.decodeFromString<List<SectionElectric>>(value) }.getOrElse { emptyList() }
+        runCatching { json.decodeFromString<List<SectionElectric>>(value) }.getOrElse { e ->
+            println("LocomotiveMapper: Failed to decode electric sections: ${e.message}")
+            emptyList()
+        }
 
     private fun decodeDieselSections(value: String): List<SectionDiesel> =
-        runCatching { json.decodeFromString<List<SectionDiesel>>(value) }.getOrElse { emptyList() }
+        runCatching { json.decodeFromString<List<SectionDiesel>>(value) }.getOrElse { e ->
+            println("LocomotiveMapper: Failed to decode diesel sections: ${e.message}")
+            emptyList()
+        }
 
     fun toData(row: LocomotiveRow): Locomotive = Locomotive(
         locoId = row.locoId,

--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/TrainMapper.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/TrainMapper.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+private val json = Json { ignoreUnknownKeys = true; isLenient = true; encodeDefaults = true }
 
 /**
  * Compat row for deserializing stations stored by old GSON code
@@ -17,8 +17,8 @@ private val json = Json { ignoreUnknownKeys = true; isLenient = true }
  */
 @Serializable
 private data class StationRow(
-    val stationId: String,
-    val trainId: String,
+    val stationId: String = "",
+    val trainId: String = "",
     @SerialName("stationName") val stationNameGson: String? = null,
     @SerialName("name") val stationNameNew: String? = null,
     val timeArrival: Long? = null,
@@ -44,7 +44,10 @@ internal object TrainMapper {
     private fun decodeStations(value: String): MutableList<Station> =
         runCatching {
             json.decodeFromString<List<StationRow>>(value).map { it.toStation() }.toMutableList()
-        }.getOrElse { mutableListOf() }
+        }.getOrElse { e ->
+            println("TrainMapper: Failed to decode stations: ${e.message}, raw=$value")
+            mutableListOf()
+        }
 
     private fun decodeServicePhase(value: String?): ServicePhase? =
         value?.let {

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
@@ -211,6 +211,7 @@ class TrainFormViewModel(
                     train.stations = stationsListState.map { state ->
                         Station(
                             stationId = state.id,
+                            trainId = train.trainId,
                             stationName = state.station.data,
                             timeArrival = state.arrival.data,
                             timeDeparture = state.departure.data


### PR DESCRIPTION
…ationRow defaults

Корневая причина: kotlinx.serialization с encodeDefaults=false пропускает trainId="" (совпадает с default) при кодировании Station. При декодировании StationRow.trainId (non-nullable, без default) вызывает MissingFieldException, которая молча ловится runCatching → возвращается пустой список станций.

Изменения:
- TrainMapper: encodeDefaults=true в Json, defaults для StationRow, логирование ошибок
- LocomotiveMapper: encodeDefaults=true в Json, логирование ошибок десериализации
- TrainFormViewModel: установка trainId на Station при saveTrain()