### PR TITLE
fix: исправить десериализацию updatedAt и 307 redirect при синхронизации

### DIFF
--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/KtorRemoteRestApi.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/KtorRemoteRestApi.kt
@@ -59,7 +59,7 @@ class KtorRemoteRestApi(private val client: HttpClient) : RemoteRestApi {
         }.body()
 
     override suspend fun saveRoute(token: String, data: Route) {
-        client.post("v1/route") {
+        client.post("v1/route/") {
             contentType(ContentType.Application.Json)
             header("Authorization", token)
             setBody(data)
@@ -67,7 +67,7 @@ class KtorRemoteRestApi(private val client: HttpClient) : RemoteRestApi {
     }
 
     override suspend fun getRoutes(token: String): List<Route> =
-        client.get("v1/route") {
+        client.get("v1/route/") {
             header("Authorization", token)
         }.body()
 
@@ -79,26 +79,26 @@ class KtorRemoteRestApi(private val client: HttpClient) : RemoteRestApi {
         }.body()
 
     override suspend fun saveUserSetting(token: String, body: UserSettings): SuccessResponse =
-        client.post("v1/user_settings") {
+        client.post("v1/user_settings/") {
             contentType(ContentType.Application.Json)
             header("Authorization", token)
             setBody(body)
         }.body()
 
     override suspend fun getUserSetting(token: String): UserSettings =
-        client.get("v1/user_settings") {
+        client.get("v1/user_settings/") {
             header("Authorization", token)
         }.body()
 
     override suspend fun saveSalarySetting(token: String, body: SalarySetting): SuccessResponse =
-        client.post("v1/salary_settings") {
+        client.post("v1/salary_settings/") {
             contentType(ContentType.Application.Json)
             header("Authorization", token)
             setBody(body)
         }.body()
 
     override suspend fun getSalarySetting(token: String): SalarySetting =
-        client.get("v1/salary_settings") {
+        client.get("v1/salary_settings/") {
             header("Authorization", token)
         }.body()
 

--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
@@ -5,6 +5,7 @@ import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.HttpRedirect
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -43,6 +44,9 @@ object RemoteRestClient {
         }
         install(Logging) {
             level = LogLevel.BODY
+        }
+        install(HttpRedirect) {
+            allowHttpsDowngrade = false
         }
         install(HttpTimeout) {
             connectTimeoutMillis = 30_000

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/BasicData.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/BasicData.kt
@@ -1,5 +1,6 @@
 package com.z_company.domain.entities.route
 
+import com.z_company.domain.entities.serializers.DateAsLongSerializer
 import com.z_company.domain.util.generateId
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
@@ -13,6 +14,7 @@ data class BasicData(
     var remoteObjectId: String? = null,
     var isOnePersonOperation: Boolean = false,
     var isDeleted: Boolean = false,
+    @Serializable(with = DateAsLongSerializer::class)
     var updatedAt: Long = Clock.System.now().toEpochMilliseconds(),
     var number: String? = null,
     var timeStartWork: Long? = null,

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/serializers/Serializers.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/serializers/Serializers.kt
@@ -1,11 +1,71 @@
 package com.z_company.domain.entities.serializers
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Сериализатор для Double → String (для совместимости с сервером, который присылает числа как строки).
+ * Используется через @Contextual в Locomotive, SectionElectric.
+ * Заменяет BigDecimalAsStringSerializer.
+ */
+/**
+ * Сериализатор для updatedAt: Long.
+ * Сервер присылает дату строкой "Feb 17, 2026 17:24:45" (формат Gson DateSerializer),
+ * а локально хранится как Long epoch millis. Обрабатывает оба формата.
+ */
+object DateAsLongSerializer : KSerializer<Long> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("DateAsLong", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Long) = encoder.encodeLong(value)
+
+    override fun deserialize(decoder: Decoder): Long {
+        if (decoder is JsonDecoder) {
+            val element = decoder.decodeJsonElement()
+            if (element is JsonPrimitive) {
+                element.longOrNull?.let { return it }
+                element.content.let { return parseDateString(it) }
+            }
+        }
+        return decoder.decodeLong()
+    }
+
+    private val months = mapOf(
+        "Jan" to 1, "Feb" to 2, "Mar" to 3, "Apr" to 4,
+        "May" to 5, "Jun" to 6, "Jul" to 7, "Aug" to 8,
+        "Sep" to 9, "Oct" to 10, "Nov" to 11, "Dec" to 12
+    )
+
+    private fun parseDateString(dateStr: String): Long {
+        return runCatching {
+            // "Feb 17, 2026 17:24:45"
+            val parts = dateStr.split(" ", ":")
+            val month = months[parts[0]] ?: 1
+            val day = parts[1].trimEnd(',').toInt()
+            val year = parts[2].toInt()
+            val hour = parts[3].toInt()
+            val minute = parts[4].toInt()
+            val second = parts[5].toInt()
+            LocalDateTime(year, month, day, hour, minute, second)
+                .toInstant(TimeZone.UTC)
+                .toEpochMilliseconds()
+        }.getOrElse {
+            println("DateAsLongSerializer: Failed to parse '$dateStr': ${it.message}")
+            Clock.System.now().toEpochMilliseconds()
+        }
+    }
+}
 
 /**
  * Сериализатор для Double → String (для совместимости с сервером, который присылает числа как строки).


### PR DESCRIPTION
Проблема 1: Сервер возвращает updatedAt как строку "Feb 17, 2026 17:24:45" (формат Gson DateSerializer), а BasicData.updatedAt: Long ожидает число. Создан DateAsLongSerializer — обрабатывает оба формата (Long и строку даты).

Проблема 2: POST v1/user_settings получал 307 redirect из-за отсутствия trailing slash. Ktor не следует 307 для POST — NoTransformationFoundException. Добавлены trailing slashes ко всем data-эндпоинтам + HttpRedirect плагин.