### PR TITLE
fix: добавить expectSuccess = true для проверки HTTP-статуса при сохр…

### DIFF
--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
@@ -39,6 +39,7 @@ object RemoteRestClient {
     }
 
     private fun createClient(baseUrl: String): HttpClient = HttpClient(createHttpEngine()) {
+        expectSuccess = true
         install(ContentNegotiation) {
             json(appJson)
         }

--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/SettingManager.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/SettingManager.kt
@@ -22,12 +22,10 @@ class SettingManager(
         bearerToken: String
     ): Flow<ResultState<Unit>> = flow {
         emit(ResultState.Loading())
-        try {
-            remoteRestApi.saveUserSetting(token = bearerToken, body = userSettings)
-            emit(ResultState.Success(Unit))
-        } catch (e: Exception) {
-            emit(ResultState.Error(ErrorEntity(throwable = e)))
-        }
+        remoteRestApi.saveUserSetting(token = bearerToken, body = userSettings)
+        emit(ResultState.Success(Unit))
+    }.catch { e ->
+        emit(ResultState.Error(ErrorEntity(throwable = e)))
     }
 
     fun getUserSettingFromRemote(


### PR DESCRIPTION
…анении

- expectSuccess = true → Ktor бросает ResponseException при non-2xx
- SettingManager: унифицирована обработка ошибок через .catch {}
- Теперь ResultState.Success только при реальном 200 от сервера