### PR TITLE
fix: добавить encodeDefaults = true в appJson для отправки всех полей…

### DIFF
--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
@@ -25,6 +25,7 @@ object RemoteRestClient {
     val appJson = Json {
         ignoreUnknownKeys = true
         isLenient = true
+        encodeDefaults = true
         serializersModule = SerializersModule {
             contextual(DoubleAsStringSerializer)
         }


### PR DESCRIPTION
… на сервер

Сервер возвращал 422 — обязательные поля отсутствовали в JSON. kotlinx.serialization по умолчанию пропускает поля с дефолтными значениями, в отличие от Gson, который всегда сериализовал все поля.