### PR TITLE
fix: добавить explicitNulls = false — не отправлять null-поля на сервер

### DIFF
--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/RemoteRestClient.kt
@@ -26,6 +26,7 @@ object RemoteRestClient {
         ignoreUnknownKeys = true
         isLenient = true
         encodeDefaults = true
+        explicitNulls = false
         serializersModule = SerializersModule {
             contextual(DoubleAsStringSerializer)
         }


### PR DESCRIPTION
Сервер использует dict.get("field", default) для обработки JSON. Когда null-поле присутствует явно, .get() возвращает null вместо default, что вызывает TypeError (int(null), float(null)) → 500. explicitNulls = false исключает null-поля из JSON, как делал Gson.