### PR TITLE
feat: реактивное обновление дочерних сущностей в FormScreen + проверк…

### DIFF
--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/SqlDelightRouteRepository.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/SqlDelightRouteRepository.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -168,11 +169,36 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
     }
 
     override fun loadRoute(routeId: String): Flow<ResultState<Route?>> {
-        return flowMap {
-            db.basicDataQueries.getById(routeId)
-                .asFlow()
-                .mapToOneOrNull(Dispatchers.Default)
-                .map { basicData -> ResultState.Success(basicData?.let { assembleRoute(it) }) }
+        return flow {
+            emit(ResultState.Loading())
+            emitAll(
+                combine(
+                    db.basicDataQueries.getById(routeId)
+                        .asFlow().mapToOneOrNull(Dispatchers.Default),
+                    db.locomotiveQueries.getByBasicId(routeId)
+                        .asFlow().mapToList(Dispatchers.Default),
+                    db.trainQueries.getByBasicId(routeId)
+                        .asFlow().mapToList(Dispatchers.Default),
+                    db.passengerQueries.getByBasicId(routeId)
+                        .asFlow().mapToList(Dispatchers.Default),
+                    db.photoQueries.getByBasicId(routeId)
+                        .asFlow().mapToList(Dispatchers.Default)
+                ) { basicData, locos, trains, passengers, photos ->
+                    basicData?.let { bd ->
+                        ResultState.Success(
+                            Route(
+                                basicData = BasicDataMapper.toData(bd),
+                                locomotives = locos.map { LocomotiveMapper.toData(it) }.toMutableList(),
+                                trains = trains.map { TrainMapper.toData(it) }.toMutableList(),
+                                passengers = passengers.map { PassengerMapper.toData(it) }.toMutableList(),
+                                photos = photos.map { PhotoMapper.toData(it) }.toMutableList()
+                            )
+                        ) as ResultState<Route?>
+                    } ?: ResultState.Success(null)
+                }.catch { e ->
+                    emit(ResultState.Error(ErrorEntity(e)))
+                }
+            )
         }
     }
 

--- a/features/route/src/main/java/com/z_company/route/navigation/FormDestination.kt
+++ b/features/route/src/main/java/com/z_company/route/navigation/FormDestination.kt
@@ -12,6 +12,7 @@ import com.z_company.core.ui.snackbar.ISnackbarManager
 import com.z_company.domain.navigation.Router
 import com.z_company.route.Const.NULLABLE_ID
 import com.z_company.route.ui.FormScreen
+import com.z_company.route.viewmodel.ChildEntityType
 import com.z_company.route.viewmodel.FormScreenEvent
 import com.z_company.route.viewmodel.FormViewModel
 import com.z_company.route.viewmodel.home_view_model.StartPurchasesEvent
@@ -58,6 +59,14 @@ fun FormDestination(
                         snackbarManager.show(message = "Маршрут сохранен")
                         viewModel::prepareReviewDialog
                     }
+
+                    is FormScreenEvent.NavigateToChildForm -> {
+                        when (event.entityType) {
+                            ChildEntityType.LOCOMOTIVE -> router.showEmptyLocoForm(event.basicId)
+                            ChildEntityType.TRAIN -> router.showEmptyTrainForm(event.basicId)
+                            ChildEntityType.PASSENGER -> router.showEmptyPassengerForm(event.basicId)
+                        }
+                    }
                 }
             }
         }
@@ -88,22 +97,13 @@ fun FormDestination(
         onTimeEndWorkChanged = viewModel::setTimeEndWork,
         onRestChanged = viewModel::onRestChanged,
         onChangedLocoClick = router::showChangedLocoForm,
-        onNewLocoClick = {
-            router.showEmptyLocoForm(it)
-            viewModel.preSaveRoute()
-        },
+        onNewLocoClick = { viewModel.onAddChildEntity(it, ChildEntityType.LOCOMOTIVE) },
         onDeleteLoco = viewModel::onDeleteLoco,
         onChangeTrainClick = router::showChangeTrainForm,
-        onNewTrainClick = {
-            router.showEmptyTrainForm(it)
-            viewModel.preSaveRoute()
-        },
+        onNewTrainClick = { viewModel.onAddChildEntity(it, ChildEntityType.TRAIN) },
         onDeleteTrain = viewModel::onDeleteTrain,
         onChangePassengerClick = router::showChangePassengerForm,
-        onNewPassengerClick = {
-            router.showEmptyPassengerForm(it)
-            viewModel.preSaveRoute()
-        },
+        onNewPassengerClick = { viewModel.onAddChildEntity(it, ChildEntityType.PASSENGER) },
         onDeletePassenger = viewModel::onDeletePassenger,
         nightTime = formUiState.nightTime,
         salaryForRouteState = salaryState,

--- a/features/route/src/main/java/com/z_company/route/viewmodel/FormScreenEvent.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/FormScreenEvent.kt
@@ -1,7 +1,10 @@
 package com.z_company.route.viewmodel
 
+enum class ChildEntityType { LOCOMOTIVE, TRAIN, PASSENGER }
+
 sealed class FormScreenEvent {
     object ActivatedFavoriteRoute: FormScreenEvent()
     object DeactivatedFavoriteRoute: FormScreenEvent()
     object RouteSaved: FormScreenEvent()
+    data class NavigateToChildForm(val basicId: String, val entityType: ChildEntityType) : FormScreenEvent()
 }

--- a/features/route/src/main/java/com/z_company/route/viewmodel/FormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/FormViewModel.kt
@@ -686,6 +686,28 @@ class FormViewModel(
         }
     }
 
+    fun onAddChildEntity(basicId: String, entityType: ChildEntityType) {
+        viewModelScope.launch {
+            when (routeHelper.newRouteClick()) {
+                is RouteActionsHelper.NewRouteResult.NeedSubscribeDialog -> {
+                    _alertBeforePurchasesEvent.emit(AlertBeforePurchasesEvent.ShowDialogNeedSubscribe)
+                }
+
+                is RouteActionsHelper.NewRouteResult.AlertSubscribeDialog -> {
+                    preSaveRoute()
+                    _events.emit(FormScreenEvent.NavigateToChildForm(basicId, entityType))
+                }
+
+                is RouteActionsHelper.NewRouteResult.ShowNewRouteScreen -> {
+                    preSaveRoute()
+                    _events.emit(FormScreenEvent.NavigateToChildForm(basicId, entityType))
+                }
+
+                is RouteActionsHelper.NewRouteResult.Error -> {}
+            }
+        }
+    }
+
     private fun subscribeToChanges(routeId: String) {
         loadRouteJob?.cancel()
         loadRouteJob = routeUseCase.routeDetails(routeId).onEach { routeState ->


### PR DESCRIPTION
…а подписки

loadRoute() теперь использует combine() из 5 реактивных SQLDelight flows, что обеспечивает мгновенное отображение изменений Train/Locomotive/Passenger. Добавлена проверка подписки перед навигацией на экраны добавления дочерних сущностей.