### PR TITLE
feat: улучшения экрана поезда — 8 задач

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -34,7 +34,6 @@ import Versions.parse_sdk_android_ver
 import Versions.permission_accompanist_ver
 import Versions.rebugger_ver
 import Versions.retrofit_ver
-import Versions.reveal_swipe_version
 import Versions.room_version
 import Versions.ru_ok_tracer_platform_ver
 import Versions.rustore_bom_ver
@@ -93,7 +92,6 @@ object Versions {
     const val lifecycle_runtime_version = "2.6.1"
     const val lifecycle_viewmodel_version = "2.6.1"
     const val material_compose3 = "1.4.0"
-    const val reveal_swipe_version = "1.2.0"
     const val room_version = "2.7.1"
     const val test_ext_version = "1.1.5"
     const val test_runner_version = "1.6.0-alpha01"
@@ -193,8 +191,6 @@ object Libs {
         "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_runtime_version"
     const val lifecycle_viewmodel_ktx =
         "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_viewmodel_version"
-    const val reveal_swipe =
-        "de.charlex.compose:revealswipe:$reveal_swipe_version"
     const val room_compiler =
         "androidx.room:room-compiler:$room_version"
     const val room_ktx =

--- a/features/route/build.gradle.kts
+++ b/features/route/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
     implementation(Libs.koin_android)
     implementation(Libs.koin_androidx_compose)
 
-    implementation(Libs.reveal_swipe)
     implementation(Libs.constraint_layout)
 
     implementation(Libs.accompanist_swipe_refresh)
@@ -80,7 +79,6 @@ dependencies {
     implementation(Libs.accompanist_pager_indicator)
 
     implementation(Libs.coil_compose)
-    implementation(Libs.reveal_swipe)
     implementation(Libs.maxkeppeler_sheets)
     implementation(Libs.rebugger)
 

--- a/features/route/src/main/java/com/z_company/route/component/DieselSectionItem.kt
+++ b/features/route/src/main/java/com/z_company/route/component/DieselSectionItem.kt
@@ -1,6 +1,7 @@
 package com.z_company.route.component
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,9 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -32,7 +32,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -68,12 +71,8 @@ import com.z_company.route.ui.maskInKilo
 import com.z_company.route.ui.maskInLiter
 import com.z_company.route.viewmodel.DieselSectionFormState
 import com.z_company.route.viewmodel.DieselSectionType
-import de.charlex.compose.RevealDirection
-import de.charlex.compose.RevealSwipe
-import de.charlex.compose.RevealValue
-import de.charlex.compose.rememberRevealState
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DieselSectionItem(
     index: Int,
@@ -92,7 +91,6 @@ fun DieselSectionItem(
 ) {
     val scope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
-    val revealState = rememberRevealState()
 
 //    var isKiloMode by remember { mutableStateOf(false) }
     val coeff = item.coefficient.data?.toDoubleOrNull() ?: 1.0
@@ -385,32 +383,42 @@ fun DieselSectionItem(
     val dataTextStyle = MaterialTheme.typography.bodyLarge
     val hintStyle = MaterialTheme.typography.bodyMedium
 
-    RevealSwipe(
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onDeleteItem(item)
+            }
+            false
+        }
+    )
+    SwipeToDismissBox(
         modifier = Modifier
             .fillMaxWidth()
             .padding(6.dp),
-        state = revealState,
-        directions = setOf(
-            RevealDirection.EndToStart
-        ),
-        hiddenContentEnd = {
-            IconButton(
-                onClick = {
-                    onDeleteItem(item)
-                    scope.launch {
-                        revealState.animateTo(RevealValue.Default)
-                    }
-                }
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            val color by animateColorAsState(
+                when (dismissState.targetValue) {
+                    SwipeToDismissBoxValue.Settled -> Color.Transparent
+                    SwipeToDismissBoxValue.EndToStart -> MaterialTheme.colorScheme.error.copy(alpha = 0.5f)
+                    else -> Color.Transparent
+                }, label = ""
+            )
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(color = color, shape = Shapes.medium),
+                contentAlignment = Alignment.CenterEnd
             ) {
                 Icon(
-                    modifier = Modifier.padding(end = 15.dp),
+                    modifier = Modifier.padding(end = 16.dp),
                     painter = painterResource(R.drawable.delete_24px),
-                    tint = Color.White,
+                    tint = MaterialTheme.colorScheme.surface,
                     contentDescription = null
                 )
             }
-        },
-        backgroundCardEndColor = MaterialTheme.colorScheme.error.copy(alpha = 0.5f),
+        }
     ) {
         Card(
             shape = RoundedCornerShape(0.dp),

--- a/features/route/src/main/java/com/z_company/route/component/ElectricSectionItem.kt
+++ b/features/route/src/main/java/com/z_company/route/component/ElectricSectionItem.kt
@@ -7,26 +7,33 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
@@ -42,13 +49,9 @@ import com.z_company.domain.util.str
 import com.z_company.route.R
 import com.z_company.route.viewmodel.ElectricSectionFormState
 import com.z_company.route.viewmodel.ElectricSectionType
-import de.charlex.compose.RevealDirection
-import de.charlex.compose.RevealSwipe
-import de.charlex.compose.RevealValue
-import de.charlex.compose.rememberRevealState
-import kotlinx.coroutines.launch
+import androidx.compose.ui.Alignment
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ElectricSectionItem(
     index: Int,
@@ -66,9 +69,8 @@ fun ElectricSectionItem(
     onExpandStateChanged: (Boolean) -> Unit,
     showOtherCurrent: Boolean = false
 ) {
-    val scope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
-    val revealState = rememberRevealState()
+    val scope = rememberCoroutineScope()
 
     val acceptedText = item.accepted.data ?: ""
     val deliveryText = item.delivery.data ?: ""
@@ -101,29 +103,40 @@ fun ElectricSectionItem(
 
     val noValueColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
 
-    RevealSwipe(
-        modifier = Modifier
-            .fillMaxWidth(),
-        state = revealState,
-        directions = setOf(
-            RevealDirection.EndToStart
-        ),
-        hiddenContentEnd = {
-            IconButton(onClick = {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
                 onDeleteItem(item)
-                scope.launch {
-                    revealState.animateTo(RevealValue.Default)
-                }
-            }) {
+            }
+            false
+        }
+    )
+    SwipeToDismissBox(
+        modifier = Modifier.fillMaxWidth(),
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            val color by animateColorAsState(
+                when (dismissState.targetValue) {
+                    SwipeToDismissBoxValue.Settled -> Color.Transparent
+                    SwipeToDismissBoxValue.EndToStart -> MaterialTheme.colorScheme.error.copy(alpha = 0.5f)
+                    else -> Color.Transparent
+                }, label = ""
+            )
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(color = color, shape = Shapes.medium),
+                contentAlignment = Alignment.CenterEnd
+            ) {
                 Icon(
-                    modifier = Modifier.padding(end = 15.dp),
+                    modifier = Modifier.padding(end = 16.dp),
                     painter = painterResource(R.drawable.delete_24px),
-                    tint = Color.White,
+                    tint = MaterialTheme.colorScheme.surface,
                     contentDescription = null
                 )
             }
-        },
-        backgroundCardEndColor = MaterialTheme.colorScheme.error.copy(alpha = 0.5f),
+        }
     ) {
         Card(
             shape = RoundedCornerShape(0.dp),

--- a/features/route/src/main/java/com/z_company/route/component/StationItem.kt
+++ b/features/route/src/main/java/com/z_company/route/component/StationItem.kt
@@ -1,5 +1,6 @@
 package com.z_company.route.component
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -13,14 +14,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -28,17 +28,20 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +49,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextRange
@@ -60,20 +64,12 @@ import com.z_company.core.ui.theme.Shapes
 import com.z_company.core.util.DateAndTimeConverter
 import com.z_company.core.util.DateAndTimeFormat
 import com.z_company.route.viewmodel.StationFormState
-import de.charlex.compose.RevealDirection
-import de.charlex.compose.RevealSwipe
-import de.charlex.compose.RevealValue
-import de.charlex.compose.rememberRevealState
-import kotlinx.coroutines.launch
 import java.util.Calendar
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class,
-    ExperimentalFoundationApi::class
-)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun StationItem(
     modifier: Modifier,
-    isFirst: Boolean,
     index: Int,
     stationFormState: StationFormState,
     onStationNameChanged: (Int, String) -> Unit,
@@ -86,10 +82,12 @@ fun StationItem(
     onDelete: (StationFormState) -> Unit,
     onDeleteStationName: (String) -> Unit,
     selectIndexState: MutableState<Int>,
-    dateAndTimeConverter: DateAndTimeConverter?
+    dateAndTimeConverter: DateAndTimeConverter?,
+    isReorderActive: Boolean = false,
+    onLongPress: () -> Unit = {},
+    onMoveUp: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null
 ) {
-    val revealState = rememberRevealState()
-    val scope = rememberCoroutineScope()
     val dataTextStyle = MaterialTheme.typography.bodyLarge
     val primaryColor = MaterialTheme.colorScheme.primary
     val noValueColor = primaryColor.copy(alpha = 0.5f)
@@ -108,8 +106,7 @@ fun StationItem(
             sheetState = sheetState,
             headerContent = {
                 Column(
-                    modifier = Modifier
-                        .fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
@@ -137,8 +134,7 @@ fun StationItem(
             sheetState = sheetState,
             headerContent = {
                 Column(
-                    modifier = Modifier
-                        .fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
@@ -177,14 +173,13 @@ fun StationItem(
     }
 
     val arrivalDateTime = arrivalTime.timeInMillis
-
     val departureDateTime = departureTime.timeInMillis
 
     if (showArrivalDatePicker) {
         DateTimePickerBottomSheet(
             title = "Прибытие",
             onDateTimeSelected = { timestamp ->
-                onArrivalTimeChanged(index,timestamp)
+                onArrivalTimeChanged(index, timestamp)
             },
             onDismiss = { showArrivalDatePicker = false },
             startDateTime = arrivalDateTime
@@ -195,216 +190,229 @@ fun StationItem(
         DateTimePickerBottomSheet(
             title = "Отправление",
             onDateTimeSelected = { timestamp ->
-                onDepartureTimeChanged(index,timestamp)
+                onDepartureTimeChanged(index, timestamp)
             },
             onDismiss = { showDepartureDatePicker = false },
             startDateTime = departureDateTime
         )
     }
 
-    RevealSwipe(
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentHeight(),
-        state = revealState,
-        directions = setOf(
-            RevealDirection.EndToStart
-        ),
-        hiddenContentEnd = {
-            IconButton(onClick = {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
                 onDelete(stationFormState)
-                scope.launch {
-                    revealState.animateTo(RevealValue.Default)
-                }
-            }) {
-                Icon(
-                    modifier = Modifier.padding(end = 15.dp),
-                    painter = painterResource(com.z_company.route.R.drawable.delete_24px),
-                    tint = MaterialTheme.colorScheme.secondary,
-                    contentDescription = null
-                )
             }
-        },
-        backgroundCardEndColor = MaterialTheme.colorScheme.error.copy(alpha = 0.5f),
-        shape = Shapes.medium
-    ) {
-        Card(
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
-        ) {
-            Row(
-                modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .fillMaxWidth()
-                    .padding(bottom = 2.dp, end = 2.dp, start = 1.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            false
+        }
+    )
 
-                ExposedDropdownMenuBox(
-                    modifier = Modifier
-                        .weight(0.5f),
-                    expanded = isExpandedMenu,
-                    onExpandedChange = { onExpandedMenuChange(index, it) }
+    Column(modifier = modifier.fillMaxWidth().wrapContentHeight()) {
+        SwipeToDismissBox(
+            state = dismissState,
+            enableDismissFromStartToEnd = false,
+            enableDismissFromEndToStart = !isReorderActive,
+            backgroundContent = {
+                val color by animateColorAsState(
+                    when (dismissState.targetValue) {
+                        SwipeToDismissBoxValue.Settled -> Color.Transparent
+                        SwipeToDismissBoxValue.EndToStart -> MaterialTheme.colorScheme.error.copy(alpha = 0.5f)
+                        else -> Color.Transparent
+                    }, label = ""
+                )
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(color = color, shape = Shapes.medium),
+                    contentAlignment = Alignment.CenterEnd
                 ) {
-                    var stationName by remember(key1 = stationFormState.id) {
-                        mutableStateOf(
-                            TextFieldValue(
-                                text = stationFormState.station.data ?: "",
-                                selection = TextRange(stationFormState.station.data?.length ?: 0)
-                            )
+                    Icon(
+                        modifier = Modifier.padding(end = 16.dp),
+                        painter = painterResource(com.z_company.route.R.drawable.delete_24px),
+                        tint = MaterialTheme.colorScheme.surface,
+                        contentDescription = null
+                    )
+                }
+            }
+        ) {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .height(IntrinsicSize.Min)
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {},
+                            onLongClick = onLongPress
                         )
-                    }
+                        .padding(bottom = 2.dp, end = 2.dp, start = 1.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
 
-                    LaunchedEffect(stationFormState.station.data) {
-                        if (stationName.text != stationFormState.station.data) {
-                            stationName = stationName.copy(text = stationFormState.station.data ?: "")
-                        }
-                    }
-
-                    OutlinedTextFieldApp(
+                    ExposedDropdownMenuBox(
                         modifier = Modifier
-                            .menuAnchor()
-                            .focusRequester(focusRequester)
-                            .onFocusChanged {
-                                if (!it.isFocused && stationName.text != stationFormState.station.data) {
+                            .weight(0.45f),
+                        expanded = isExpandedMenu,
+                        onExpandedChange = { onExpandedMenuChange(index, it) }
+                    ) {
+                        var stationName by remember(key1 = stationFormState.id) {
+                            mutableStateOf(
+                                TextFieldValue(
+                                    text = stationFormState.station.data ?: "",
+                                    selection = TextRange(stationFormState.station.data?.length ?: 0)
+                                )
+                            )
+                        }
+
+                        LaunchedEffect(stationFormState.station.data) {
+                            if (stationName.text != stationFormState.station.data) {
+                                stationName = stationName.copy(text = stationFormState.station.data ?: "")
+                            }
+                        }
+
+                        OutlinedTextFieldApp(
+                            modifier = Modifier
+                                .menuAnchor()
+                                .focusRequester(focusRequester)
+                                .onFocusChanged {
+                                    if (!it.isFocused && stationName.text != stationFormState.station.data) {
+                                        onStationNameChanged(index, stationName.text)
+                                    }
+                                },
+                            value = stationName,
+                            onValueChange = {
+                                stationName = it
+                                onChangedContentMenu(index, it.text)
+                            },
+                            placeholder = {
+                                Text(
+                                    text = "Станция",
+                                    style = LocalTextStyle.current.copy(
+                                        fontWeight = FontWeight.Light
+                                    ),
+                                    color = noValueColor
+                                )
+                            },
+                            textStyle = dataTextStyle,
+                            keyboardOptions = KeyboardOptions(
+                                imeAction = ImeAction.Done
+                            ),
+                            keyboardActions = KeyboardActions(
+                                onDone = {
+                                    focusManager.clearFocus()
                                     onStationNameChanged(index, stationName.text)
                                 }
-                            },
-                        value = stationName,
-                        onValueChange = {
-                            stationName = it
-                            onChangedContentMenu(index, it.text)
-                        },
-                        placeholder = {
-                            Text(
-                                text = "Станция",
-                                style = LocalTextStyle.current.copy(
-                                    fontWeight = FontWeight.Light
-                                ),
-                                color = noValueColor
-                            )
-                        },
-                        textStyle = dataTextStyle,
-                        keyboardOptions = KeyboardOptions(
-                            imeAction = ImeAction.Done
-                        ),
-                        keyboardActions = KeyboardActions(
-                            onDone = {
-                                focusManager.clearFocus()
-                                onStationNameChanged(index, stationName.text)
-                            }
-                        ),
-                        singleLine = true,
-                    )
+                            ),
+                            singleLine = true,
+                        )
 
-                    if (menuList.isNotEmpty()) {
-                        DropdownMenu(
-                            modifier = Modifier
-                                .background(
-                                    color = MaterialTheme.colorScheme.surface,
-                                    shape = Shapes.medium
-                                )
-                                .exposedDropdownSize(true),
-                            expanded = isExpandedMenu,
-                            properties = PopupProperties(focusable = false),
-                            onDismissRequest = { onExpandedMenuChange(index, false) }
-                        ) {
-                            menuList.forEach { selectionStation ->
-                                DropdownMenuItem(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .background(
-                                            color = MaterialTheme.colorScheme.surface,
-                                            shape = Shapes.medium
-                                        ),
-                                    text = {
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            horizontalArrangement = Arrangement.SpaceBetween
-                                        ) {
-                                            Text(text = selectionStation, style = dataTextStyle, color = primaryColor)
-                                            Icon(
-                                                modifier = Modifier.clickable {
-                                                    onDeleteStationName(selectionStation)
-                                                },
-                                                painter = painterResource(R.drawable.ic_clear),
-                                                contentDescription = null,
-                                                tint = primaryColor
+                        if (menuList.isNotEmpty()) {
+                            DropdownMenu(
+                                modifier = Modifier
+                                    .background(
+                                        color = MaterialTheme.colorScheme.surface,
+                                        shape = Shapes.medium
+                                    )
+                                    .exposedDropdownSize(true),
+                                expanded = isExpandedMenu,
+                                properties = PopupProperties(focusable = false),
+                                onDismissRequest = { onExpandedMenuChange(index, false) }
+                            ) {
+                                menuList.forEach { selectionStation ->
+                                    DropdownMenuItem(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .background(
+                                                color = MaterialTheme.colorScheme.surface,
+                                                shape = Shapes.medium
+                                            ),
+                                        text = {
+                                            Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.SpaceBetween
+                                            ) {
+                                                Text(text = selectionStation, style = dataTextStyle, color = primaryColor)
+                                                Icon(
+                                                    modifier = Modifier.clickable {
+                                                        onDeleteStationName(selectionStation)
+                                                    },
+                                                    painter = painterResource(R.drawable.ic_clear),
+                                                    contentDescription = null,
+                                                    tint = primaryColor
+                                                )
+                                            }
+                                        },
+                                        onClick = {
+                                            onStationNameChanged(index, selectionStation)
+                                            onExpandedMenuChange(index, false)
+                                            stationName = stationName.copy(
+                                                text = selectionStation,
+                                                selection = TextRange(selectionStation.length)
                                             )
-                                        }
-
-                                    },
-                                    onClick = {
-                                        onStationNameChanged(index, selectionStation)
-                                        onExpandedMenuChange(index, false)
-                                        stationName = stationName.copy(
-                                            text = selectionStation,
-                                            selection = TextRange(selectionStation.length)
-                                        )
-                                    })
+                                        })
+                                }
                             }
                         }
                     }
-                }
 
-                val animatedBackgroundColorsArrival by animateColorAsState(
-                    targetValue = if (stationFormState.arrival.data == null) MaterialTheme.colorScheme.surface
-                    else MaterialTheme.colorScheme.secondary,
-                    animationSpec = tween(
-                        durationMillis = 200,
-                        easing = FastOutSlowInEasing
-                    )
-                )
-
-                val animatedBackgroundColorsDeparture by animateColorAsState(
-                    targetValue = if (stationFormState.departure.data == null) MaterialTheme.colorScheme.surface
-                    else MaterialTheme.colorScheme.secondary,
-                    animationSpec = tween(
-                        durationMillis = 200,
-                        easing = FastOutSlowInEasing
-                    )
-                )
-
-                val animatedTextColorsArrival by animateColorAsState(
-                    targetValue = if (stationFormState.arrival.data == null) primaryColor.copy(alpha = 0.5f)
-                    else primaryColor,
-                    animationSpec = tween(
-                        durationMillis = 200,
-                        easing = FastOutSlowInEasing
-                    )
-                )
-                val animatedTextColorsDeparture by animateColorAsState(
-                    targetValue = if (stationFormState.departure.data == null) primaryColor.copy(alpha = 0.5f)
-                    else primaryColor,
-                    animationSpec = tween(
-                        durationMillis = 200,
-                        easing = FastOutSlowInEasing
-                    )
-                )
-
-                Box(
-                    modifier = Modifier
-                        .weight(0.25f)
-                        .shadow(elevation = 2.dp, shape = Shapes.medium)
-                        .fillMaxHeight()
-                        .background(
-                            color = animatedBackgroundColorsArrival,
-                            shape = Shapes.medium
+                    val animatedBackgroundColorsArrival by animateColorAsState(
+                        targetValue = if (stationFormState.arrival.data == null) MaterialTheme.colorScheme.surface
+                        else MaterialTheme.colorScheme.secondary,
+                        animationSpec = tween(
+                            durationMillis = 200,
+                            easing = FastOutSlowInEasing
                         )
-                        .combinedClickable(
-                            onClick = {
-                                showArrivalDatePicker = true
-                            },
-                            onLongClick = {
-                                selectIndexState.value = index
-                                stationFormState.arrival.data?.let {
-                                    showBottomSheetRemoveTimeArrival = true
+                    )
+
+                    val animatedBackgroundColorsDeparture by animateColorAsState(
+                        targetValue = if (stationFormState.departure.data == null) MaterialTheme.colorScheme.surface
+                        else MaterialTheme.colorScheme.secondary,
+                        animationSpec = tween(
+                            durationMillis = 200,
+                            easing = FastOutSlowInEasing
+                        )
+                    )
+
+                    val animatedTextColorsArrival by animateColorAsState(
+                        targetValue = if (stationFormState.arrival.data == null) primaryColor.copy(alpha = 0.5f)
+                        else primaryColor,
+                        animationSpec = tween(
+                            durationMillis = 200,
+                            easing = FastOutSlowInEasing
+                        )
+                    )
+                    val animatedTextColorsDeparture by animateColorAsState(
+                        targetValue = if (stationFormState.departure.data == null) primaryColor.copy(alpha = 0.5f)
+                        else primaryColor,
+                        animationSpec = tween(
+                            durationMillis = 200,
+                            easing = FastOutSlowInEasing
+                        )
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .weight(0.2f)
+                            .shadow(elevation = 2.dp, shape = Shapes.medium)
+                            .fillMaxHeight()
+                            .background(
+                                color = animatedBackgroundColorsArrival,
+                                shape = Shapes.medium
+                            )
+                            .combinedClickable(
+                                onClick = {
+                                    showArrivalDatePicker = true
+                                },
+                                onLongClick = {
+                                    selectIndexState.value = index
+                                    stationFormState.arrival.data?.let {
+                                        showBottomSheetRemoveTimeArrival = true
+                                    }
                                 }
-                            }
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (!isFirst) {
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
                         val textTimeArrival = stationFormState.arrival.data?.let {
                             dateAndTimeConverter?.getTimeFromDateLong(it)
                         } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
@@ -416,39 +424,84 @@ fun StationItem(
                             color = animatedTextColorsArrival
                         )
                     }
-                }
-                Box(
-                    modifier = Modifier
-                        .weight(0.25f)
-                        .shadow(elevation = 2.dp, shape = Shapes.medium)
-                        .fillMaxHeight()
-                        .background(
-                            color = animatedBackgroundColorsDeparture,
-                            shape = Shapes.medium
-                        )
-                        .combinedClickable(
-                            onClick = {
-                                showDepartureDatePicker = true
-                            },
-                            onLongClick = {
-                                selectIndexState.value = index
-                                stationFormState.departure.data?.let {
-                                    showBottomSheetRemoveTimeDeparture = true
-                                }
-                            }
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val textTimeDeparture = stationFormState.departure.data?.let {
-                        dateAndTimeConverter?.getTimeFromDateLong(it)
-                    } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
 
-                    Text(
-                        text = textTimeDeparture,
-                        maxLines = 1,
-                        style = dataTextStyle,
-                        color = animatedTextColorsDeparture
-                    )
+                    // Стоянка (минуты между прибытием и отправлением)
+                    val stopMinutes = if (stationFormState.arrival.data != null && stationFormState.departure.data != null) {
+                        val diff = stationFormState.departure.data - stationFormState.arrival.data
+                        if (diff > 0) (diff / 60_000).toString() else null
+                    } else null
+
+                    if (stopMinutes != null) {
+                        Text(
+                            text = "${stopMinutes}'",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = primaryColor.copy(alpha = 0.7f)
+                        )
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .weight(0.2f)
+                            .shadow(elevation = 2.dp, shape = Shapes.medium)
+                            .fillMaxHeight()
+                            .background(
+                                color = animatedBackgroundColorsDeparture,
+                                shape = Shapes.medium
+                            )
+                            .combinedClickable(
+                                onClick = {
+                                    showDepartureDatePicker = true
+                                },
+                                onLongClick = {
+                                    selectIndexState.value = index
+                                    stationFormState.departure.data?.let {
+                                        showBottomSheetRemoveTimeDeparture = true
+                                    }
+                                }
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        val textTimeDeparture = stationFormState.departure.data?.let {
+                            dateAndTimeConverter?.getTimeFromDateLong(it)
+                        } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
+
+                        Text(
+                            text = textTimeDeparture,
+                            maxLines = 1,
+                            style = dataTextStyle,
+                            color = animatedTextColorsDeparture
+                        )
+                    }
+                }
+            }
+        }
+
+        // Кнопки перемещения при reorder mode
+        AnimatedVisibility(visible = isReorderActive) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (onMoveUp != null) {
+                    IconButton(onClick = onMoveUp) {
+                        Icon(
+                            painter = painterResource(com.z_company.route.R.drawable.keyboard_arrow_up_24px),
+                            contentDescription = "Переместить вверх",
+                            tint = primaryColor
+                        )
+                    }
+                }
+                if (onMoveDown != null) {
+                    IconButton(onClick = onMoveDown) {
+                        Icon(
+                            painter = painterResource(com.z_company.route.R.drawable.keyboard_arrow_down_24px),
+                            contentDescription = "Переместить вниз",
+                            tint = primaryColor
+                        )
+                    }
                 }
             }
         }

--- a/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
@@ -206,6 +206,91 @@ fun FormTrainScreen(
 
         var showSelectServicePhase by remember { mutableStateOf(false) }
 
+        if (formUiState.showCreateServicePhaseSheet) {
+            var newPhaseDistance by remember { mutableStateOf("") }
+            val createPhaseSheetState = rememberModalBottomSheetState(
+                skipPartiallyExpanded = true
+            )
+            ModalBottomSheet(
+                onDismissRequest = { viewModel.dismissCreateServicePhaseSheet() },
+                sheetState = createPhaseSheetState,
+                containerColor = MaterialTheme.colorScheme.secondary,
+                dragHandle = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 12.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .width(40.dp)
+                                .height(4.dp)
+                                .clip(RoundedCornerShape(2.dp))
+                                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.5f))
+                        )
+                    }
+                }
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = "Новое плечо",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = primaryColor
+                    )
+                    Text(
+                        text = "${formUiState.suggestedDepartureStation} — ${formUiState.suggestedArrivalStation}",
+                        style = dataTextStyle,
+                        color = primaryColor
+                    )
+                    OutlinedTextFieldApp(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = newPhaseDistance,
+                        onValueChange = { newPhaseDistance = it },
+                        placeholder = {
+                            Text(
+                                text = "Расстояние",
+                                style = LocalTextStyle.current.copy(fontWeight = FontWeight.Light),
+                                color = noValueColor
+                            )
+                        },
+                        suffix = {
+                            Text(text = "км", style = hintStyle, color = noValueColor)
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = ImeAction.Done
+                        ),
+                        textStyle = dataTextStyle,
+                        singleLine = true
+                    )
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = Shapes.medium,
+                        onClick = { viewModel.createServicePhaseAndSave(newPhaseDistance) }
+                    ) {
+                        Text(text = "Добавить", style = MaterialTheme.typography.bodySmall)
+                    }
+                    TextButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { viewModel.dismissCreateServicePhaseSheet() }
+                    ) {
+                        Text(
+                            text = "Пропустить",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = primaryColor.copy(alpha = 0.7f)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(40.dp))
+                }
+            }
+        }
+
         if (showSelectServicePhase) {
             ModalBottomSheet(
                 onDismissRequest = { showSelectServicePhase = false },
@@ -386,7 +471,7 @@ fun FormTrainScreen(
                                 OutlinedTextFieldApp(
                                     modifier = Modifier
                                         .weight(1f),
-                                    value = train.distance ?: "",
+                                    value = train.distance?.takeIf { it != "0" } ?: "",
                                     onValueChange = {
                                         onDistanceChange(it)
                                     },
@@ -513,7 +598,7 @@ fun FormTrainScreen(
                             OutlinedTextFieldApp(
                                 modifier = Modifier
                                     .weight(1f),
-                                value = train.weight ?: "",
+                                value = train.weight?.takeIf { it != "0" } ?: "",
                                 onValueChange = {
                                     onWeightChanged(it)
                                 },
@@ -553,7 +638,7 @@ fun FormTrainScreen(
                             OutlinedTextFieldApp(
                                 modifier = Modifier
                                     .weight(1f),
-                                value = train.axle ?: "",
+                                value = train.axle?.takeIf { it != "0" } ?: "",
                                 onValueChange = {
                                     onAxleChanged(it)
                                 },
@@ -593,7 +678,7 @@ fun FormTrainScreen(
                             OutlinedTextFieldApp(
                                 modifier = Modifier
                                     .weight(1f),
-                                value = train.conditionalLength ?: "",
+                                value = train.conditionalLength?.takeIf { it != "0" } ?: "",
                                 onValueChange = {
                                     onLengthChanged(it)
                                 },
@@ -717,10 +802,6 @@ fun FormTrainScreen(
                             items = displayList,
                             key = { _, item -> item.id }
                         ) { index, item ->
-                            val isFirst =
-                                if (formUiState.isStationsReversed) index == stationList.lastIndex
-                                else index == 0
-
                             val originalIndex = if (formUiState.isStationsReversed) stationList.size - 1 - index else index
 
                             Spacer(
@@ -731,7 +812,6 @@ fun FormTrainScreen(
                             StationItem(
                                 modifier = Modifier.animateItem(),
                                 index = originalIndex,
-                                isFirst = isFirst,
                                 stationFormState = item,
                                 onDelete = onDeleteStation,
                                 menuList = menuList,
@@ -745,7 +825,15 @@ fun FormTrainScreen(
                                 onDepartureTimeChanged = onDepartureTimeChanged,
                                 onDeleteStationName = onDeleteStationName,
                                 selectIndexState = selectSectionIndexState,
-                                dateAndTimeConverter = dateAndTimeConverter
+                                dateAndTimeConverter = dateAndTimeConverter,
+                                isReorderActive = formUiState.reorderStationIndex == originalIndex,
+                                onLongPress = { viewModel.setReorderStation(originalIndex) },
+                                onMoveUp = if (originalIndex > 0) {
+                                    { viewModel.moveStation(originalIndex, originalIndex - 1) }
+                                } else null,
+                                onMoveDown = if (originalIndex < stationList.lastIndex) {
+                                    { viewModel.moveStation(originalIndex, originalIndex + 1) }
+                                } else null
                             )
                         }
                     }

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormUiState.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormUiState.kt
@@ -20,5 +20,9 @@ data class TrainFormUiState(
     val servicePhaseList: SnapshotStateList<ServicePhase> = mutableStateListOf(),
     val selectedServicePhase: ServicePhase? = null,
     var dateAndTimeConverter: DateAndTimeConverter? = null,
-    var isStationsReversed: Boolean = false
+    var isStationsReversed: Boolean = false,
+    val reorderStationIndex: Int? = null,
+    val showCreateServicePhaseSheet: Boolean = false,
+    val suggestedDepartureStation: String = "",
+    val suggestedArrivalStation: String = ""
 )

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -97,15 +96,31 @@ class TrainFormViewModel(
             if (servicePhase != uiState.value.selectedServicePhase || uiState.value.selectedServicePhase == null) {
                 if (stationsListState.isEmpty()) {
                     addingStation(stationName = servicePhase.departureStation)
-                }
-                if (stationsListState.isNotEmpty() && stationsListState.first().station.data != servicePhase.departureStation) {
-                    stationsListState[0] = StationFormState(
-                        id = Station().stationId,
-                        station = StationField(
-                            data = servicePhase.departureStation,
-                            type = StationDataType.NAME
+                    addingStation(stationName = servicePhase.arrivalStation)
+                } else {
+                    // Обновить первую станцию
+                    if (stationsListState.first().station.data != servicePhase.departureStation) {
+                        stationsListState[0] = stationsListState[0].copy(
+                            station = StationField(
+                                data = servicePhase.departureStation,
+                                type = StationDataType.NAME
+                            )
                         )
-                    )
+                    }
+                    // Обновить/добавить последнюю станцию
+                    if (stationsListState.size == 1) {
+                        addingStation(stationName = servicePhase.arrivalStation)
+                    } else {
+                        val lastIdx = stationsListState.lastIndex
+                        if (stationsListState[lastIdx].station.data != servicePhase.arrivalStation) {
+                            stationsListState[lastIdx] = stationsListState[lastIdx].copy(
+                                station = StationField(
+                                    data = servicePhase.arrivalStation,
+                                    type = StationDataType.NAME
+                                )
+                            )
+                        }
+                    }
                     changesHave()
                 }
             }
@@ -148,10 +163,14 @@ class TrainFormViewModel(
             }
             initJob.join()
 
-            combine(
-                settingsUseCase.getFlowCurrentSettingsState(),
-                routeUseCase.routeDetails(basicId)
-            ) { settingState, routeState ->
+            // Load route once
+            val routeState = routeUseCase.routeDetails(basicId).first()
+            if (routeState is ResultState.Success) {
+                routeState.data?.let { route = it }
+            }
+
+            // Subscribe to settings changes (service phases can be updated)
+            settingsUseCase.getFlowCurrentSettingsState().collect { settingState ->
                 if (settingState is ResultState.Success) {
                     settingState.data.let { settings ->
                         _uiState.update {
@@ -160,16 +179,12 @@ class TrainFormViewModel(
                             )
                         }
                         stationNameList.addAllOrSkip(settings.stationList.toMutableStateList())
+                        mutableStationList.addAllOrSkip(stationNameList)
                         servicePhaseList.clear()
                         servicePhaseList.addAllOrSkip(settings.servicePhases.toMutableStateList())
                     }
                 }
-                if (routeState is ResultState.Success) {
-                    routeState.data?.let {
-                        route = it
-                    }
-                }
-            }.collect {}
+            }
         }
 
     }
@@ -217,15 +232,79 @@ class TrainFormViewModel(
                             timeDeparture = state.departure.data
                         )
                     }.toMutableList()
-                    saveStationsName(train)
-                    saveTrainJob?.cancel()
-                    saveTrainJob = viewModelScope.launch {
-                        trainUseCase.saveTrain(train).collect { resultState ->
+
+                    // Check if first+last station matches an existing service phase
+                    val firstStation = stationsListState.firstOrNull()?.station?.data
+                    val lastStation = stationsListState.lastOrNull()?.station?.data
+                    if (!firstStation.isNullOrBlank() && !lastStation.isNullOrBlank() && stationsListState.size >= 2) {
+                        val matchingPhase = servicePhaseList.any { phase ->
+                            phase.departureStation == firstStation && phase.arrivalStation == lastStation
+                        }
+                        if (!matchingPhase) {
                             _uiState.update {
-                                it.copy(saveTrainState = resultState)
+                                it.copy(
+                                    showCreateServicePhaseSheet = true,
+                                    suggestedDepartureStation = firstStation,
+                                    suggestedArrivalStation = lastStation
+                                )
                             }
+                            return
                         }
                     }
+
+                    performSave(train)
+                }
+            }
+        }
+    }
+
+    private fun performSave(train: Train) {
+        saveStationsName(train)
+        saveTrainJob?.cancel()
+        saveTrainJob = viewModelScope.launch {
+            trainUseCase.saveTrain(train).collect { resultState ->
+                _uiState.update {
+                    it.copy(saveTrainState = resultState)
+                }
+            }
+        }
+    }
+
+    fun dismissCreateServicePhaseSheet() {
+        _uiState.update {
+            it.copy(showCreateServicePhaseSheet = false)
+        }
+        // Just save the train without creating a service phase
+        val state = _uiState.value.trainDetailState
+        if (state is ResultState.Success) {
+            state.data?.let { performSave(it) }
+        }
+    }
+
+    fun createServicePhaseAndSave(distance: String) {
+        _uiState.update {
+            it.copy(showCreateServicePhaseSheet = false)
+        }
+        viewModelScope.launch {
+            val uiValue = _uiState.value
+            val newPhase = ServicePhase(
+                departureStation = uiValue.suggestedDepartureStation,
+                arrivalStation = uiValue.suggestedArrivalStation,
+                distance = distance.toIntOrNull() ?: 0
+            )
+            // Get current settings and add new service phase
+            val currentSettings = settingsUseCase.getUserSettingFlow().first()
+            val updatedSettings = currentSettings.copy(
+                servicePhases = currentSettings.servicePhases + newPhase
+            )
+            settingsUseCase.saveSetting(updatedSettings).first()
+
+            // Now save the train
+            val state = _uiState.value.trainDetailState
+            if (state is ResultState.Success) {
+                state.data?.let { train ->
+                    train.servicePhase = newPhase
+                    performSave(train)
                 }
             }
         }
@@ -312,18 +391,36 @@ class TrainFormViewModel(
     }
 
     fun addingStation(stationName: String? = null) {
-        stationsListState.add(
-            element = StationFormState(
-                id = Station().stationId,
-                station = StationField(data = stationName, type = StationDataType.NAME)
-            )
+        val newStation = StationFormState(
+            id = Station().stationId,
+            station = StationField(data = stationName, type = StationDataType.NAME)
         )
+        val hasServicePhase = _uiState.value.selectedServicePhase != null
+        if (hasServicePhase && stationsListState.size >= 2 && stationName == null) {
+            stationsListState.add(stationsListState.lastIndex, newStation)
+        } else {
+            stationsListState.add(newStation)
+        }
         changesHave()
     }
 
     fun deleteStation(stationFormState: StationFormState) {
         checkFormValidStation()
         stationsListState.remove(stationFormState)
+        changesHave()
+    }
+
+    fun setReorderStation(index: Int?) {
+        _uiState.update {
+            it.copy(reorderStationIndex = if (it.reorderStationIndex == index) null else index)
+        }
+    }
+
+    fun moveStation(fromIndex: Int, toIndex: Int) {
+        if (toIndex < 0 || toIndex >= stationsListState.size) return
+        val item = stationsListState.removeAt(fromIndex)
+        stationsListState.add(toIndex, item)
+        _uiState.update { it.copy(reorderStationIndex = toIndex) }
         changesHave()
     }
 
@@ -361,18 +458,16 @@ class TrainFormViewModel(
 
     private fun checkFormValidStation() {
         viewModelScope.launch {
-            route = route.copy(
-                trains = mutableListOf(
-                    currentTrain!!.copy(
-                        stations = stationsListState.map { state ->
-                            Station(
-                                stationId = state.id,
-                                stationName = state.station.data,
-                                timeArrival = state.arrival.data,
-                                timeDeparture = state.departure.data
-                            )
-                        }.toMutableList()
-                    )
+            route.trains = mutableListOf(
+                currentTrain!!.copy(
+                    stations = stationsListState.map { state ->
+                        Station(
+                            stationId = state.id,
+                            stationName = state.station.data,
+                            timeArrival = state.arrival.data,
+                            timeDeparture = state.departure.data
+                        )
+                    }.toMutableList()
                 )
             )
 
@@ -393,16 +488,6 @@ class TrainFormViewModel(
             }
         }
     }
-
-//    private fun formValidStation(
-//        station: Station
-//    ): Boolean {
-//
-//        routeUseCase.isValidTrain(route)
-//        val departure = station.timeDeparture
-//        val arrival = station.timeArrival
-//        return arrival.compareWithNullable(departure)
-//    }
 
     fun setStationName(index: Int, s: String?) {
         onStationEvent(
@@ -445,9 +530,6 @@ class TrainFormViewModel(
     }
 
     private var mutableStationList = mutableStateListOf<String>()
-        .also {
-            it.addAll(stationNameList)
-        }
 
     var stationList: SnapshotStateList<String>
         get() {


### PR DESCRIPTION
1. Пустое поле при значении "0" (distance, weight, axle, conditionalLength)
2. Плечо устанавливает обе станции (первую и последнюю), вставка перед последней
3. Long press на станцию — кнопки перемещения ↑/↓ только для этой станции
4. RevealSwipe → SwipeToDismissBox (StationItem, DieselSectionItem, ElectricSectionItem), удалена зависимость revealswipe
5. Предложение создать новое плечо при сохранении (ModalBottomSheet)
6. Время прибытия для всех станций (убрано ограничение isFirst)
7. Стоянка в минутах между прибытием и отправлением
8. Оптимизации ViewModel: route загружается однократно, route.trains обновляется in-place, mutableStationList заполняется из подписки