### PR TITLE
fix: корректировки экрана поезда

### DIFF
--- a/features/route/src/main/java/com/z_company/route/component/StationItem.kt
+++ b/features/route/src/main/java/com/z_company/route/component/StationItem.kt
@@ -18,7 +18,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Card
@@ -63,8 +65,13 @@ import com.z_company.core.ui.component.DateTimePickerBottomSheet
 import com.z_company.core.ui.theme.Shapes
 import com.z_company.core.util.DateAndTimeConverter
 import com.z_company.core.util.DateAndTimeFormat
+import com.z_company.domain.entities.route.UtilsForEntities
 import com.z_company.route.viewmodel.StationFormState
 import java.util.Calendar
+
+private val warningColor = Color(0xFFFFC107)
+private val warningTextColor = Color(0xFF3E2723)
+private val dangerColor = Color(0xFFEF5350)
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -83,8 +90,8 @@ fun StationItem(
     onDeleteStationName: (String) -> Unit,
     selectIndexState: MutableState<Int>,
     dateAndTimeConverter: DateAndTimeConverter?,
-    isReorderActive: Boolean = false,
-    onLongPress: () -> Unit = {},
+    trainNumber: String? = null,
+    isReorderMode: Boolean = false,
     onMoveUp: (() -> Unit)? = null,
     onMoveDown: (() -> Unit)? = null
 ) {
@@ -206,11 +213,37 @@ fun StationItem(
         }
     )
 
+    // Стоянка (минуты между прибытием и отправлением)
+    val stopMinutes = if (stationFormState.arrival.data != null && stationFormState.departure.data != null) {
+        val diff = stationFormState.departure.data - stationFormState.arrival.data
+        if (diff > 0) (diff / 60_000).toString() else null
+    } else null
+
+    // Определение пассажирского поезда
+    val isPassengerTrain = trainNumber?.toIntOrNull()?.let { num ->
+        UtilsForEntities.passengerTrainNumberList.any { range -> num in range }
+    } ?: false
+
+    // Цвета фона стоянки
+    val stopLong = stopMinutes?.toLongOrNull() ?: 0L
+    val stopBackground = when {
+        stopLong > 20 && isPassengerTrain -> dangerColor
+        stopLong > 30 -> dangerColor
+        stopLong > 5 -> warningColor
+        else -> Color.Transparent
+    }
+    val stopTextColor = when {
+        stopLong > 20 && isPassengerTrain -> Color.White
+        stopLong > 30 -> Color.White
+        stopLong > 5 -> warningTextColor
+        else -> primaryColor.copy(alpha = 0.7f)
+    }
+
     Column(modifier = modifier.fillMaxWidth().wrapContentHeight()) {
         SwipeToDismissBox(
             state = dismissState,
             enableDismissFromStartToEnd = false,
-            enableDismissFromEndToStart = !isReorderActive,
+            enableDismissFromEndToStart = !isReorderMode,
             backgroundContent = {
                 val color by animateColorAsState(
                     when (dismissState.targetValue) {
@@ -241,18 +274,14 @@ fun StationItem(
                     modifier = Modifier
                         .height(IntrinsicSize.Min)
                         .fillMaxWidth()
-                        .combinedClickable(
-                            onClick = {},
-                            onLongClick = onLongPress
-                        )
                         .padding(bottom = 2.dp, end = 2.dp, start = 1.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
 
                     ExposedDropdownMenuBox(
                         modifier = Modifier
-                            .weight(0.45f),
+                            .weight(0.5f),
                         expanded = isExpandedMenu,
                         onExpandedChange = { onExpandedMenuChange(index, it) }
                     ) {
@@ -356,128 +385,149 @@ fun StationItem(
                         }
                     }
 
-                    val animatedBackgroundColorsArrival by animateColorAsState(
-                        targetValue = if (stationFormState.arrival.data == null) MaterialTheme.colorScheme.surface
-                        else MaterialTheme.colorScheme.secondary,
-                        animationSpec = tween(
-                            durationMillis = 200,
-                            easing = FastOutSlowInEasing
-                        )
-                    )
-
-                    val animatedBackgroundColorsDeparture by animateColorAsState(
-                        targetValue = if (stationFormState.departure.data == null) MaterialTheme.colorScheme.surface
-                        else MaterialTheme.colorScheme.secondary,
-                        animationSpec = tween(
-                            durationMillis = 200,
-                            easing = FastOutSlowInEasing
-                        )
-                    )
-
-                    val animatedTextColorsArrival by animateColorAsState(
-                        targetValue = if (stationFormState.arrival.data == null) primaryColor.copy(alpha = 0.5f)
-                        else primaryColor,
-                        animationSpec = tween(
-                            durationMillis = 200,
-                            easing = FastOutSlowInEasing
-                        )
-                    )
-                    val animatedTextColorsDeparture by animateColorAsState(
-                        targetValue = if (stationFormState.departure.data == null) primaryColor.copy(alpha = 0.5f)
-                        else primaryColor,
-                        animationSpec = tween(
-                            durationMillis = 200,
-                            easing = FastOutSlowInEasing
-                        )
-                    )
-
-                    Box(
+                    // Время (arrival + стоянка + departure) — 50%
+                    Row(
                         modifier = Modifier
-                            .weight(0.2f)
-                            .shadow(elevation = 2.dp, shape = Shapes.medium)
-                            .fillMaxHeight()
-                            .background(
-                                color = animatedBackgroundColorsArrival,
-                                shape = Shapes.medium
-                            )
-                            .combinedClickable(
-                                onClick = {
-                                    showArrivalDatePicker = true
-                                },
-                                onLongClick = {
-                                    selectIndexState.value = index
-                                    stationFormState.arrival.data?.let {
-                                        showBottomSheetRemoveTimeArrival = true
-                                    }
-                                }
-                            ),
-                        contentAlignment = Alignment.Center
+                            .weight(0.5f)
+                            .fillMaxHeight(),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        val textTimeArrival = stationFormState.arrival.data?.let {
-                            dateAndTimeConverter?.getTimeFromDateLong(it)
-                        } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
-
-                        Text(
-                            text = textTimeArrival,
-                            maxLines = 1,
-                            style = dataTextStyle,
-                            color = animatedTextColorsArrival
-                        )
-                    }
-
-                    // Стоянка (минуты между прибытием и отправлением)
-                    val stopMinutes = if (stationFormState.arrival.data != null && stationFormState.departure.data != null) {
-                        val diff = stationFormState.departure.data - stationFormState.arrival.data
-                        if (diff > 0) (diff / 60_000).toString() else null
-                    } else null
-
-                    if (stopMinutes != null) {
-                        Text(
-                            text = "${stopMinutes}'",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = primaryColor.copy(alpha = 0.7f)
-                        )
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .weight(0.2f)
-                            .shadow(elevation = 2.dp, shape = Shapes.medium)
-                            .fillMaxHeight()
-                            .background(
-                                color = animatedBackgroundColorsDeparture,
-                                shape = Shapes.medium
+                        val animatedBackgroundColorsArrival by animateColorAsState(
+                            targetValue = if (stationFormState.arrival.data == null) MaterialTheme.colorScheme.surface
+                            else MaterialTheme.colorScheme.secondary,
+                            animationSpec = tween(
+                                durationMillis = 200,
+                                easing = FastOutSlowInEasing
                             )
-                            .combinedClickable(
-                                onClick = {
-                                    showDepartureDatePicker = true
-                                },
-                                onLongClick = {
-                                    selectIndexState.value = index
-                                    stationFormState.departure.data?.let {
-                                        showBottomSheetRemoveTimeDeparture = true
-                                    }
-                                }
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        val textTimeDeparture = stationFormState.departure.data?.let {
-                            dateAndTimeConverter?.getTimeFromDateLong(it)
-                        } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
-
-                        Text(
-                            text = textTimeDeparture,
-                            maxLines = 1,
-                            style = dataTextStyle,
-                            color = animatedTextColorsDeparture
                         )
+
+                        val animatedBackgroundColorsDeparture by animateColorAsState(
+                            targetValue = if (stationFormState.departure.data == null) MaterialTheme.colorScheme.surface
+                            else MaterialTheme.colorScheme.secondary,
+                            animationSpec = tween(
+                                durationMillis = 200,
+                                easing = FastOutSlowInEasing
+                            )
+                        )
+
+                        val animatedTextColorsArrival by animateColorAsState(
+                            targetValue = if (stationFormState.arrival.data == null) primaryColor.copy(alpha = 0.5f)
+                            else primaryColor,
+                            animationSpec = tween(
+                                durationMillis = 200,
+                                easing = FastOutSlowInEasing
+                            )
+                        )
+                        val animatedTextColorsDeparture by animateColorAsState(
+                            targetValue = if (stationFormState.departure.data == null) primaryColor.copy(alpha = 0.5f)
+                            else primaryColor,
+                            animationSpec = tween(
+                                durationMillis = 200,
+                                easing = FastOutSlowInEasing
+                            )
+                        )
+
+                        // Arrival time
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .shadow(elevation = 2.dp, shape = Shapes.medium)
+                                .fillMaxHeight()
+                                .background(
+                                    color = animatedBackgroundColorsArrival,
+                                    shape = Shapes.medium
+                                )
+                                .combinedClickable(
+                                    onClick = {
+                                        showArrivalDatePicker = true
+                                    },
+                                    onLongClick = {
+                                        selectIndexState.value = index
+                                        stationFormState.arrival.data?.let {
+                                            showBottomSheetRemoveTimeArrival = true
+                                        }
+                                    }
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            val textTimeArrival = stationFormState.arrival.data?.let {
+                                dateAndTimeConverter?.getTimeFromDateLong(it)
+                            } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
+
+                            Text(
+                                text = textTimeArrival,
+                                maxLines = 1,
+                                style = dataTextStyle,
+                                color = animatedTextColorsArrival
+                            )
+                        }
+
+                        // Стоянка (фиксированная ширина 40dp)
+                        Box(
+                            modifier = Modifier.width(40.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (stopMinutes != null) {
+                                Box(
+                                    modifier = Modifier
+                                        .background(stopBackground, RoundedCornerShape(4.dp))
+                                        .padding(horizontal = 2.dp, vertical = 1.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = "${stopMinutes}'",
+                                        style = MaterialTheme.typography.labelSmall.copy(
+                                            fontWeight = FontWeight.Bold
+                                        ),
+                                        color = stopTextColor,
+                                        maxLines = 1
+                                    )
+                                }
+                            }
+                        }
+
+                        // Departure time
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .shadow(elevation = 2.dp, shape = Shapes.medium)
+                                .fillMaxHeight()
+                                .background(
+                                    color = animatedBackgroundColorsDeparture,
+                                    shape = Shapes.medium
+                                )
+                                .combinedClickable(
+                                    onClick = {
+                                        showDepartureDatePicker = true
+                                    },
+                                    onLongClick = {
+                                        selectIndexState.value = index
+                                        stationFormState.departure.data?.let {
+                                            showBottomSheetRemoveTimeDeparture = true
+                                        }
+                                    }
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            val textTimeDeparture = stationFormState.departure.data?.let {
+                                dateAndTimeConverter?.getTimeFromDateLong(it)
+                            } ?: DateAndTimeFormat.DEFAULT_TIME_TEXT
+
+                            Text(
+                                text = textTimeDeparture,
+                                maxLines = 1,
+                                style = dataTextStyle,
+                                color = animatedTextColorsDeparture
+                            )
+                        }
                     }
                 }
             }
         }
 
         // Кнопки перемещения при reorder mode
-        AnimatedVisibility(visible = isReorderActive) {
+        AnimatedVisibility(visible = isReorderMode) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
@@ -207,12 +207,12 @@ fun FormTrainScreen(
         var showSelectServicePhase by remember { mutableStateOf(false) }
 
         if (formUiState.showCreateServicePhaseSheet) {
-            var newPhaseDistance by remember { mutableStateOf("") }
+            var newPhaseDistance by remember { mutableStateOf(currentTrain?.distance?.takeIf { it != "0" } ?: "") }
             val createPhaseSheetState = rememberModalBottomSheetState(
                 skipPartiallyExpanded = true
             )
             ModalBottomSheet(
-                onDismissRequest = { viewModel.dismissCreateServicePhaseSheet() },
+                onDismissRequest = { viewModel.cancelCreateServicePhaseSheet() },
                 sheetState = createPhaseSheetState,
                 containerColor = MaterialTheme.colorScheme.secondary,
                 dragHandle = {
@@ -269,6 +269,7 @@ fun FormTrainScreen(
                         textStyle = dataTextStyle,
                         singleLine = true
                     )
+                    Spacer(modifier = Modifier.height(12.dp))
                     Button(
                         modifier = Modifier.fillMaxWidth(),
                         shape = Shapes.medium,
@@ -278,7 +279,7 @@ fun FormTrainScreen(
                     }
                     TextButton(
                         modifier = Modifier.fillMaxWidth(),
-                        onClick = { viewModel.dismissCreateServicePhaseSheet() }
+                        onClick = { viewModel.skipServicePhaseAndSave() }
                     ) {
                         Text(
                             text = "Пропустить",
@@ -612,7 +613,7 @@ fun FormTrainScreen(
                                     )
                                 },
                                 suffix = {
-                                    if (!train.weight.isNullOrBlank()) {
+                                    if (!train.weight.isNullOrBlank() && train.weight != "0") {
                                         Text(
                                             text = "т.",
                                             style = hintStyle,
@@ -652,7 +653,7 @@ fun FormTrainScreen(
                                     )
                                 },
                                 suffix = {
-                                    if (!train.axle.isNullOrBlank()) {
+                                    if (!train.axle.isNullOrBlank() && train.axle != "0") {
                                         Text(
                                             text = "о.",
                                             style = hintStyle,
@@ -692,7 +693,7 @@ fun FormTrainScreen(
                                     )
                                 },
                                 suffix = {
-                                    if (!train.conditionalLength.isNullOrBlank()) {
+                                    if (!train.conditionalLength.isNullOrBlank() && train.conditionalLength != "0") {
                                         Text(
                                             text = "у.д.",
                                             style = hintStyle,
@@ -793,6 +794,18 @@ fun FormTrainScreen(
                                 painter = painterResource(com.z_company.route.R.drawable.sort_24px),
                                 contentDescription = null
                             )
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Icon(
+                                modifier = Modifier
+                                    .noRippleEffect(
+                                        onClick = {
+                                            viewModel.toggleReorderMode()
+                                        }
+                                    ),
+                                painter = painterResource(com.z_company.route.R.drawable.swap_vert_24px),
+                                contentDescription = null,
+                                tint = if (formUiState.isReorderMode) MaterialTheme.colorScheme.tertiary else primaryColor
+                            )
                         }
                     }
 
@@ -826,8 +839,8 @@ fun FormTrainScreen(
                                 onDeleteStationName = onDeleteStationName,
                                 selectIndexState = selectSectionIndexState,
                                 dateAndTimeConverter = dateAndTimeConverter,
-                                isReorderActive = formUiState.reorderStationIndex == originalIndex,
-                                onLongPress = { viewModel.setReorderStation(originalIndex) },
+                                trainNumber = train.number,
+                                isReorderMode = formUiState.isReorderMode,
                                 onMoveUp = if (originalIndex > 0) {
                                     { viewModel.moveStation(originalIndex, originalIndex - 1) }
                                 } else null,

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormUiState.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormUiState.kt
@@ -21,7 +21,7 @@ data class TrainFormUiState(
     val selectedServicePhase: ServicePhase? = null,
     var dateAndTimeConverter: DateAndTimeConverter? = null,
     var isStationsReversed: Boolean = false,
-    val reorderStationIndex: Int? = null,
+    val isReorderMode: Boolean = false,
     val showCreateServicePhaseSheet: Boolean = false,
     val suggestedDepartureStation: String = "",
     val suggestedArrivalStation: String = ""

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
@@ -270,11 +270,18 @@ class TrainFormViewModel(
         }
     }
 
-    fun dismissCreateServicePhaseSheet() {
+    fun cancelCreateServicePhaseSheet() {
         _uiState.update {
             it.copy(showCreateServicePhaseSheet = false)
         }
-        // Just save the train without creating a service phase
+        // User dismissed the sheet — cancel save, stay on screen
+    }
+
+    fun skipServicePhaseAndSave() {
+        _uiState.update {
+            it.copy(showCreateServicePhaseSheet = false)
+        }
+        // Save the train without creating a service phase
         val state = _uiState.value.trainDetailState
         if (state is ResultState.Success) {
             state.data?.let { performSave(it) }
@@ -410,9 +417,9 @@ class TrainFormViewModel(
         changesHave()
     }
 
-    fun setReorderStation(index: Int?) {
+    fun toggleReorderMode() {
         _uiState.update {
-            it.copy(reorderStationIndex = if (it.reorderStationIndex == index) null else index)
+            it.copy(isReorderMode = !it.isReorderMode)
         }
     }
 
@@ -420,7 +427,6 @@ class TrainFormViewModel(
         if (toIndex < 0 || toIndex >= stationsListState.size) return
         val item = stationsListState.removeAt(fromIndex)
         stationsListState.add(toIndex, item)
-        _uiState.update { it.copy(reorderStationIndex = toIndex) }
         changesHave()
     }
 

--- a/features/route/src/main/res/drawable/swap_vert_24px.xml
+++ b/features/route/src/main/res/drawable/swap_vert_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16,17.01V10h-2v7.01h-3L15,21l4,-3.99h-3zM9,3L5,6.99h3V14h2V6.99h3L9,3z"/>
+</vector>


### PR DESCRIPTION
1. BottomSheet плеча: предзаполнение расстояния из train.distance
2. Dismiss шторки (свайп вниз) отменяет сохранение, остаёмся на экране
3. Увеличен отступ перед кнопкой «Добавить» в BottomSheet
4. Суффиксы «т.», «о.», «у.д.» скрываются при значении «0»
5. StationItem: layout 50/50, стоянка в фиксированном блоке 40dp
6. Стоянка: жирный шрифт, жёлтый фон >5мин, красный >20мин(пасс)/30мин
7. Reorder: toggle-кнопка swap_vert вместо long press, режим для всех станций