### PR TITLE
fix: play/pause не заполняет конечную станцию плеча + кнопка времени …

### DIFF
--- a/data_local/src/androidMain/kotlin/com/z_company/data_local/SharedPreferenceStorage.kt
+++ b/data_local/src/androidMain/kotlin/com/z_company/data_local/SharedPreferenceStorage.kt
@@ -20,6 +20,7 @@ private const val TOKEN_INPUT_DIESEL_IN_KILO = "TOKEN_INPUT_DIESEL_IN_KILO"
 private const val SORT_OPTION_TAG = "SORT_OPTION"
 private const val SELECTED_FILTERS_TAG = "SELECTED_FILTERS"
 private const val IS_EXPANDED_VIEW_TAG = "IS_EXPANDED_VIEW"
+private const val SHOW_TRAVEL_TIME_TAG = "SHOW_TRAVEL_TIME"
 private const val TOKEN_IS_MIGRATED = "TOKEN_IS_MIGRATED"
 
 private const val OP_KEY_PREF = "OP_KEY_PREF"
@@ -141,4 +142,11 @@ class SharedPreferenceStorage(application: Application) : SharedPreferencesRepos
     override fun setIsExpandedView(value: Boolean) {
         editor.putBoolean(IS_EXPANDED_VIEW_TAG, value).apply()
     }
+
+    override fun toggleShowTravelTime(value: Boolean) {
+        editor.putBoolean(SHOW_TRAVEL_TIME_TAG, value).apply()
+    }
+
+    override fun isShowTravelTime(): Boolean =
+        sharedpref.getBoolean(SHOW_TRAVEL_TIME_TAG, false)
 }

--- a/domain/src/commonMain/kotlin/com/z_company/domain/repositories/SharedPreferencesRepositories.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/repositories/SharedPreferencesRepositories.kt
@@ -28,4 +28,6 @@ interface SharedPreferencesRepositories {
     fun setSelectedFilters(values: Set<String>)
     fun isExpandedView(): Boolean
     fun setIsExpandedView(value: Boolean)
+    fun toggleShowTravelTime(value: Boolean)
+    fun isShowTravelTime(): Boolean
 }

--- a/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -812,6 +813,18 @@ fun FormTrainScreen(
                                     contentDescription = null,
                                     tint = if (formUiState.isReorderMode) MaterialTheme.colorScheme.tertiary else primaryColor
                                 )
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Icon(
+                                    modifier = Modifier
+                                        .noRippleEffect(
+                                            onClick = {
+                                                viewModel.toggleTravelTimeMode()
+                                            }
+                                        ),
+                                    painter = painterResource(com.z_company.route.R.drawable.schedule_24px),
+                                    contentDescription = null,
+                                    tint = if (formUiState.isShowTravelTime) MaterialTheme.colorScheme.tertiary else primaryColor
+                                )
                             }
 
                             // Правая часть: play/pause
@@ -851,6 +864,32 @@ fun FormTrainScreen(
                                     .height(8.dp)
                                     .animateItem()
                             )
+
+                            // Время перегона между станциями
+                            if (index > 0 && formUiState.isShowTravelTime) {
+                                val (fromIdx, toIdx) = if (formUiState.isStationsReversed) {
+                                    Pair(originalIndex, originalIndex + 1)
+                                } else {
+                                    Pair(originalIndex - 1, originalIndex)
+                                }
+                                if (fromIdx in stationList.indices && toIdx in stationList.indices) {
+                                    val depTime = stationList[fromIdx].departure.data
+                                    val arrTime = stationList[toIdx].arrival.data
+                                    if (depTime != null && arrTime != null && arrTime > depTime) {
+                                        val travelMinutes = (arrTime - depTime) / 60_000
+                                        Text(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .animateItem(),
+                                            text = "${travelMinutes}'",
+                                            textAlign = TextAlign.Center,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = primaryColor.copy(alpha = 0.5f)
+                                        )
+                                    }
+                                }
+                            }
+
                             StationItem(
                                 modifier = Modifier.animateItem(),
                                 index = originalIndex,

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormUiState.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormUiState.kt
@@ -22,6 +22,7 @@ data class TrainFormUiState(
     var dateAndTimeConverter: DateAndTimeConverter? = null,
     var isStationsReversed: Boolean = false,
     val isReorderMode: Boolean = false,
+    val isShowTravelTime: Boolean = false,
     val showCreateServicePhaseSheet: Boolean = false,
     val suggestedDepartureStation: String = "",
     val suggestedArrivalStation: String = ""

--- a/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/TrainFormViewModel.kt
@@ -147,9 +147,23 @@ class TrainFormViewModel(
         sharedPreferenceStorage.toggleStationsSortOrder(newReversed)
     }
 
+    fun loadTravelTimeMode() {
+        viewModelScope.launch {
+            val isShow = sharedPreferenceStorage.isShowTravelTime()
+            _uiState.update { it.copy(isShowTravelTime = isShow) }
+        }
+    }
+
+    fun toggleTravelTimeMode() {
+        val newValue = !_uiState.value.isShowTravelTime
+        _uiState.update { it.copy(isShowTravelTime = newValue, isReorderMode = false) }
+        sharedPreferenceStorage.toggleShowTravelTime(newValue)
+    }
+
     init {
         viewModelScope.launch {
             loadStationsSortOrder()
+            loadTravelTimeMode()
             if (trainId == NULLABLE_ID) {
                 isNewTrain = true
                 currentTrain = Train(basicId = basicId)
@@ -480,11 +494,12 @@ class TrainFormViewModel(
         } else {
             // Последнее заполненное — departure → arrival на следующей станции
             val nextIdx = idx + 1
-            if (nextIdx <= stationsListState.lastIndex) {
-                // Следующая станция уже существует
+            val isServicePhaseArrival = hasServicePhase && nextIdx == stationsListState.lastIndex
+            if (nextIdx <= stationsListState.lastIndex && !isServicePhaseArrival) {
+                // Следующая станция уже существует и это не конечная станция плеча
                 setArrivalTime(nextIdx, now)
             } else {
-                // Нужно добавить новую станцию
+                // Нужно добавить новую станцию (или nextIdx указывает на конечную станцию плеча)
                 addingStation() // с плечом вставит перед последней, без — в конец
                 if (hasServicePhase) {
                     setArrivalTime(stationsListState.lastIndex - 1, now)
@@ -496,8 +511,12 @@ class TrainFormViewModel(
     }
 
     fun toggleReorderMode() {
+        val wasShowingTravelTime = _uiState.value.isShowTravelTime
         _uiState.update {
-            it.copy(isReorderMode = !it.isReorderMode)
+            it.copy(isReorderMode = !it.isReorderMode, isShowTravelTime = false)
+        }
+        if (wasShowingTravelTime) {
+            sharedPreferenceStorage.toggleShowTravelTime(false)
         }
     }
 


### PR DESCRIPTION
…перегона

- onGoClicked: проверка isServicePhaseArrival — конечная станция плеча не заполняется кнопкой play/pause, вместо этого добавляется промежуточная
- Новая кнопка schedule в ряду sort/swap для показа времени перегона между станциями (departure → arrival следующей) в минутах
- Взаимоисключение: travel time деактивирует reorder и наоборот
- Состояние кнопки сохраняется в SharedPreferences