### PR TITLE
fix: TooltipBox с detectTapGestures + .collect {} для удаления в save…

### DIFF
--- a/features/route/src/main/java/com/z_company/route/component/StationItem.kt
+++ b/features/route/src/main/java/com/z_company/route/component/StationItem.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BasicTooltipBox
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,6 +50,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +60,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextRange
@@ -72,6 +76,7 @@ import com.z_company.core.util.DateAndTimeConverter
 import com.z_company.core.util.DateAndTimeFormat
 import com.z_company.domain.entities.route.UtilsForEntities
 import com.z_company.route.viewmodel.StationFormState
+import kotlinx.coroutines.launch
 import java.util.Calendar
 
 private val warningColor = Color(0xFFFFC107)
@@ -493,40 +498,67 @@ fun StationItem(
                         }
 
                         // Стоянка (фиксированная ширина 40dp)
-
-                        BasicTooltipBox(
-                            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                            tooltip = { Text("Время стоянки") },
-                            state = rememberBasicTooltipState()
-                        ) {
-                            Box(
-                                modifier = Modifier.width(40.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                if (stopMinutes != null) {
+                        run {
+                            val stopTooltipState = rememberBasicTooltipState(isPersistent = false)
+                            val stopTooltipScope = rememberCoroutineScope()
+                            BasicTooltipBox(
+                                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                                tooltip = {
                                     Box(
                                         modifier = Modifier
-                                            .background(stopBackground, RoundedCornerShape(4.dp))
-                                            .padding(horizontal = 2.dp, vertical = 1.dp),
-                                        contentAlignment = Alignment.Center
+                                            .background(
+                                                shape = Shapes.medium,
+                                                color = MaterialTheme.colorScheme.surface
+                                            )
+                                            .padding(12.dp)
                                     ) {
                                         Text(
-                                            text = "${stopMinutes}'",
-                                            style = MaterialTheme.typography.labelSmall.copy(
-                                                fontWeight = FontWeight.Bold
-                                            ),
-                                            color = stopTextColor,
-                                            maxLines = 1,
-                                            softWrap = false,
-                                            onTextLayout = { result ->
-                                                if (result.hasVisualOverflow) {
-                                                    timeTextStyle = timeTextStyle.copy(
-                                                        fontSize = timeTextStyle.fontSize * 0.9
-                                                    )
-                                                }
-
-                                            }
+                                            text = "Время стоянки",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.primary
                                         )
+                                    }
+                                },
+                                state = stopTooltipState
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .width(40.dp)
+                                        .pointerInput(Unit) {
+                                            detectTapGestures(
+                                                onPress = {
+                                                    stopTooltipScope.launch {
+                                                        stopTooltipState.show(MutatePriority.Default)
+                                                    }
+                                                }
+                                            )
+                                        },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (stopMinutes != null) {
+                                        Box(
+                                            modifier = Modifier
+                                                .background(stopBackground, RoundedCornerShape(4.dp))
+                                                .padding(horizontal = 2.dp, vertical = 1.dp),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Text(
+                                                text = "${stopMinutes}'",
+                                                style = MaterialTheme.typography.labelSmall.copy(
+                                                    fontWeight = FontWeight.Bold
+                                                ),
+                                                color = stopTextColor,
+                                                maxLines = 1,
+                                                softWrap = false,
+                                                onTextLayout = { result ->
+                                                    if (result.hasVisualOverflow) {
+                                                        timeTextStyle = timeTextStyle.copy(
+                                                            fontSize = timeTextStyle.fontSize * 0.9
+                                                        )
+                                                    }
+                                                }
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
@@ -12,9 +12,11 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BasicTooltipBox
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
@@ -71,6 +73,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.dimensionResource
@@ -820,22 +823,47 @@ fun FormTrainScreen(
                                     tint = if (formUiState.isReorderMode) MaterialTheme.colorScheme.tertiary else primaryColor
                                 )
                                 Spacer(modifier = Modifier.width(12.dp))
-                                BasicTooltipBox(
-                                    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                                    tooltip = { Text("Перегонное время") },
-                                    state = rememberBasicTooltipState()
-                                ) {
-                                    Icon(
-                                        modifier = Modifier
-                                            .noRippleEffect(
-                                                onClick = {
-                                                    viewModel.toggleTravelTimeMode()
-                                                }
-                                            ),
-                                        painter = painterResource(com.z_company.route.R.drawable.schedule_24px),
-                                        contentDescription = null,
-                                        tint = if (formUiState.isShowTravelTime) MaterialTheme.colorScheme.tertiary else primaryColor
-                                    )
+                                run {
+                                    val travelTimeTooltipState = rememberBasicTooltipState(isPersistent = false)
+                                    BasicTooltipBox(
+                                        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                                        tooltip = {
+                                            Box(
+                                                modifier = Modifier
+                                                    .background(
+                                                        shape = Shapes.medium,
+                                                        color = MaterialTheme.colorScheme.surface
+                                                    )
+                                                    .padding(12.dp)
+                                            ) {
+                                                Text(
+                                                    text = "Перегонное время",
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                            }
+                                        },
+                                        state = travelTimeTooltipState
+                                    ) {
+                                        Icon(
+                                            modifier = Modifier
+                                                .pointerInput(Unit) {
+                                                    detectTapGestures(
+                                                        onTap = {
+                                                            viewModel.toggleTravelTimeMode()
+                                                        },
+                                                        onLongPress = {
+                                                            scope.launch {
+                                                                travelTimeTooltipState.show(MutatePriority.Default)
+                                                            }
+                                                        }
+                                                    )
+                                                },
+                                            painter = painterResource(com.z_company.route.R.drawable.schedule_24px),
+                                            contentDescription = null,
+                                            tint = if (formUiState.isShowTravelTime) MaterialTheme.colorScheme.tertiary else primaryColor
+                                        )
+                                    }
                                 }
                             }
 

--- a/features/route/src/main/java/com/z_company/route/viewmodel/FormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/FormViewModel.kt
@@ -533,13 +533,13 @@ class FormViewModel(
                     _uiState.update { it.copy(saveRouteState = result) }
                     if (result is ResultState.Success) {
                         deletedLocoList.forEach { loco ->
-                            locoUseCase.removeLoco(loco)
+                            locoUseCase.removeLoco(loco).collect {}
                         }
                         deletedTrainList.forEach { train ->
-                            trainUseCase.removeTrain(train)
+                            trainUseCase.removeTrain(train).collect {}
                         }
                         deletedPassengerList.forEach { passenger ->
-                            passengerUseCase.removePassenger(passenger)
+                            passengerUseCase.removePassenger(passenger).collect {}
                         }
                         _events.emit(FormScreenEvent.RouteSaved)
                     }


### PR DESCRIPTION
…Route

- TooltipBox "Перегонное время": detectTapGestures(onTap/onLongPress) вместо noRippleEffect (который перехватывал все жесты)
- TooltipBox "Время стоянки": pointerInput + detectTapGestures(onPress) с ручным вызовом state.show(MutatePriority.Default)
- Стилизация tooltip как в HomeScreen: Box с background/padding
- saveRoute(): добавлен .collect {} к removeLoco/removeTrain/removePassenger (Flow — cold stream, без терминальной операции не запускается)