### PR TITLE
fix: tooltip на значение перегонного времени + стоянка с полной высот…

### DIFF
--- a/features/route/src/main/java/com/z_company/route/component/StationItem.kt
+++ b/features/route/src/main/java/com/z_company/route/component/StationItem.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,7 +23,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Card
@@ -60,7 +58,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextRange
@@ -498,68 +495,57 @@ fun StationItem(
                         }
 
                         // Стоянка (фиксированная ширина 40dp)
-                        run {
-                            val stopTooltipState = rememberBasicTooltipState(isPersistent = false)
-                            val stopTooltipScope = rememberCoroutineScope()
-                            BasicTooltipBox(
-                                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                                tooltip = {
-                                    Box(
-                                        modifier = Modifier
-                                            .background(
-                                                shape = Shapes.medium,
-                                                color = MaterialTheme.colorScheme.surface
-                                            )
-                                            .padding(12.dp)
-                                    ) {
-                                        Text(
-                                            text = "Время стоянки",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.primary
-                                        )
-                                    }
-                                },
-                                state = stopTooltipState
-                            ) {
+                        val stopTooltipState = rememberBasicTooltipState(isPersistent = false)
+                        val stopTooltipScope = rememberCoroutineScope()
+                        BasicTooltipBox(
+                            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                            tooltip = {
                                 Box(
                                     modifier = Modifier
-                                        .width(40.dp)
-                                        .pointerInput(Unit) {
-                                            detectTapGestures(
-                                                onPress = {
-                                                    stopTooltipScope.launch {
-                                                        stopTooltipState.show(MutatePriority.Default)
-                                                    }
-                                                }
-                                            )
-                                        },
-                                    contentAlignment = Alignment.Center
+                                        .background(
+                                            shape = Shapes.medium,
+                                            color = MaterialTheme.colorScheme.surface
+                                        )
+                                        .padding(12.dp)
                                 ) {
-                                    if (stopMinutes != null) {
-                                        Box(
-                                            modifier = Modifier
-                                                .background(stopBackground, RoundedCornerShape(4.dp))
-                                                .padding(horizontal = 2.dp, vertical = 1.dp),
-                                            contentAlignment = Alignment.Center
-                                        ) {
-                                            Text(
-                                                text = "${stopMinutes}'",
-                                                style = MaterialTheme.typography.labelSmall.copy(
-                                                    fontWeight = FontWeight.Bold
-                                                ),
-                                                color = stopTextColor,
-                                                maxLines = 1,
-                                                softWrap = false,
-                                                onTextLayout = { result ->
-                                                    if (result.hasVisualOverflow) {
-                                                        timeTextStyle = timeTextStyle.copy(
-                                                            fontSize = timeTextStyle.fontSize * 0.9
-                                                        )
-                                                    }
-                                                }
-                                            )
+                                    Text(
+                                        text = "Время стоянки",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            },
+                            state = stopTooltipState
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .width(40.dp)
+                                    .fillMaxHeight()
+                                    .background(stopBackground, Shapes.medium)
+                                    .clickable {
+                                        stopTooltipScope.launch {
+                                            stopTooltipState.show(MutatePriority.Default)
                                         }
-                                    }
+                                    },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                if (stopMinutes != null) {
+                                    Text(
+                                        text = "${stopMinutes}'",
+                                        style = MaterialTheme.typography.labelSmall.copy(
+                                            fontWeight = FontWeight.Bold
+                                        ),
+                                        color = stopTextColor,
+                                        maxLines = 1,
+                                        softWrap = false,
+                                        onTextLayout = { result ->
+                                            if (result.hasVisualOverflow) {
+                                                timeTextStyle = timeTextStyle.copy(
+                                                    fontSize = timeTextStyle.fontSize * 0.9
+                                                )
+                                            }
+                                        }
+                                    )
                                 }
                             }
                         }

--- a/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormTrainScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
@@ -823,46 +821,17 @@ fun FormTrainScreen(
                                     tint = if (formUiState.isReorderMode) MaterialTheme.colorScheme.tertiary else primaryColor
                                 )
                                 Spacer(modifier = Modifier.width(12.dp))
-                                val travelTimeTooltipState = rememberBasicTooltipState(isPersistent = false)
-                                BasicTooltipBox(
-                                    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                                    tooltip = {
-                                        Box(
-                                            modifier = Modifier
-                                                .background(
-                                                    shape = Shapes.medium,
-                                                    color = MaterialTheme.colorScheme.surface
-                                                )
-                                                .padding(12.dp)
-                                        ) {
-                                            Text(
-                                                text = "Перегонное время",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.primary
-                                            )
-                                        }
-                                    },
-                                    state = travelTimeTooltipState
-                                ) {
-                                    Icon(
-                                        modifier = Modifier
-                                            .combinedClickable(
-                                                indication = null,
-                                                interactionSource = remember { MutableInteractionSource() },
-                                                onClick = {
-                                                    viewModel.toggleTravelTimeMode()
-                                                },
-                                                onLongClick = {
-                                                    scope.launch {
-                                                        travelTimeTooltipState.show(MutatePriority.Default)
-                                                    }
-                                                }
-                                            ),
-                                        painter = painterResource(com.z_company.route.R.drawable.schedule_24px),
-                                        contentDescription = null,
-                                        tint = if (formUiState.isShowTravelTime) MaterialTheme.colorScheme.tertiary else primaryColor
-                                    )
-                                }
+                                Icon(
+                                    modifier = Modifier
+                                        .noRippleEffect(
+                                            onClick = {
+                                                viewModel.toggleTravelTimeMode()
+                                            }
+                                        ),
+                                    painter = painterResource(com.z_company.route.R.drawable.schedule_24px),
+                                    contentDescription = null,
+                                    tint = if (formUiState.isShowTravelTime) MaterialTheme.colorScheme.tertiary else primaryColor
+                                )
                             }
 
                             // Правая часть: play/pause
@@ -919,20 +888,48 @@ fun FormTrainScreen(
                                     if (depTime != null && arrTime != null && arrTime > depTime) {
                                         val travelMinutesInLong = (arrTime - depTime)
                                         val travelMinutes = ConverterLongToTime.getTimeInStringFormat(travelMinutesInLong)
+                                        val travelTooltipState = rememberBasicTooltipState(isPersistent = false)
                                         Row(
                                             modifier = Modifier
                                                 .animateItem()
                                                 .fillMaxWidth()
                                                 .padding(bottom = 2.dp)
                                         ) {
-                                            Text(
-                                                modifier = Modifier
-                                                    .weight(1f),
-                                                text = travelMinutes,
-                                                textAlign = TextAlign.Center,
-                                                style = MaterialTheme.typography.labelSmall,
-                                                color = primaryColor.copy(alpha = 0.7f)
-                                            )
+                                            BasicTooltipBox(
+                                                modifier = Modifier.weight(1f),
+                                                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                                                tooltip = {
+                                                    Box(
+                                                        modifier = Modifier
+                                                            .background(
+                                                                shape = Shapes.medium,
+                                                                color = MaterialTheme.colorScheme.surface
+                                                            )
+                                                            .padding(12.dp)
+                                                    ) {
+                                                        Text(
+                                                            text = "Перегонное время",
+                                                            style = MaterialTheme.typography.bodyMedium,
+                                                            color = MaterialTheme.colorScheme.primary
+                                                        )
+                                                    }
+                                                },
+                                                state = travelTooltipState
+                                            ) {
+                                                Text(
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .clickable {
+                                                            scope.launch {
+                                                                travelTooltipState.show(MutatePriority.Default)
+                                                            }
+                                                        },
+                                                    text = travelMinutes,
+                                                    textAlign = TextAlign.Center,
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = primaryColor.copy(alpha = 0.7f)
+                                                )
+                                            }
                                             Box(
                                                 modifier = Modifier.weight(1f)
                                             )


### PR DESCRIPTION
…ой и Shapes.medium

- Убран BasicTooltipBox с иконки schedule, возвращён простой noRippleEffect
- Добавлен BasicTooltipBox "Перегонное время" на само значение перегонного времени между станциями (показывается по короткому нажатию)
- Стоянка: fillMaxHeight + background(Shapes.medium) вместо внутреннего Box с RoundedCornerShape(4.dp) — фон во всю высоту с закруглением как у остальных
- Убраны неиспользуемые импорты (combinedClickable, MutableInteractionSource, detectTapGestures, pointerInput, RoundedCornerShape)