### PR TITLE
fix: обнуление секунд при вычислении стоянки в таймлайне и шторке

### DIFF
--- a/features/route/src/main/java/com/z_company/route/component/StationEditBottomSheet.kt
+++ b/features/route/src/main/java/com/z_company/route/component/StationEditBottomSheet.kt
@@ -230,7 +230,9 @@ fun StationEditBottomSheet(
 
             // ── Бейдж стоянки (между прибытием и отправлением) ──
             val stopMinutes = if (localArrival != null && localDeparture != null) {
-                val diff = localDeparture!! - localArrival!!
+                val arr = localArrival!! - localArrival!! % 60_000L
+                val dep = localDeparture!! - localDeparture!! % 60_000L
+                val diff = dep - arr
                 if (diff > 0) (diff / 60_000).toInt() else null
             } else null
 

--- a/features/route/src/main/java/com/z_company/route/component/TrainStationTimeline.kt
+++ b/features/route/src/main/java/com/z_company/route/component/TrainStationTimeline.kt
@@ -93,7 +93,7 @@ private fun formatTime(millis: Long): String {
 private fun calculateStop(item: StationTimelineItem): StopInfo? {
     val arrival = item.timeArrival ?: return null
     val departure = item.timeDeparture ?: return null
-    val diff = departure - arrival
+    val diff = (departure - departure % 60_000L) - (arrival - arrival % 60_000L)
     return if (diff > 0) StopInfo(diff) else null
 }
 


### PR DESCRIPTION
- TrainStationTimeline.calculateStop(): truncate arrival/departure к минутам
- StationEditBottomSheet: truncate при расчёте stopMinutes