### PR TITLE
fix: отображение всех номеров поезда в HomeScreen и ItemHomeScreen

### DIFF
--- a/features/route/src/main/java/com/z_company/route/component/ItemHomeScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/component/ItemHomeScreen.kt
@@ -240,8 +240,12 @@ fun ItemHomeScreen(
                                 route.trains
                                     .sortedBy { it.stations.firstOrNull()?.timeDeparture }
                                     .forEach { train ->
-                                        val trainNumber = if (!train.number.isNullOrBlank()) {
-                                            "\u2116${train.number} "
+                                        val allNumbers = buildList {
+                                            train.number?.takeIf { it.isNotBlank() }?.let { add(it) }
+                                            addAll(train.additionalNumbers)
+                                        }
+                                        val trainNumber = if (allNumbers.isNotEmpty()) {
+                                            "\u2116${allNumbers.joinToString(", ")} "
                                         } else {
                                             ""
                                         }
@@ -311,8 +315,12 @@ fun ItemHomeScreen(
                                     .fillMaxWidth(),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                val trainNumber = if (!train.number.isNullOrBlank()) {
-                                    "\u2116${train.number} "
+                                val allNumbers = buildList {
+                                    train.number?.takeIf { it.isNotBlank() }?.let { add(it) }
+                                    addAll(train.additionalNumbers)
+                                }
+                                val trainNumber = if (allNumbers.isNotEmpty()) {
+                                    "\u2116${allNumbers.joinToString(", ")} "
                                 } else {
                                     ""
                                 }

--- a/features/route/src/main/java/com/z_company/route/ui/HomeScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/HomeScreen.kt
@@ -808,8 +808,13 @@ fun HomeScreen(
                                                                     )
                                                                 }
                                                         ) {
-                                                            val numberTrainText =
-                                                                train.number ?: "???"
+                                                            val allNumbers = buildList {
+                                                                train.number?.let { add(it) }
+                                                                addAll(train.additionalNumbers)
+                                                            }
+                                                            val numberTrainText = if (allNumbers.isNotEmpty())
+                                                                allNumbers.joinToString(", ")
+                                                            else "???"
                                                             Text(
                                                                 text = "№ $numberTrainText",
                                                                 color = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
Собирает primary number + additionalNumbers через buildList/joinToString. Исправлено в 3 местах: текущий маршрут HomeScreen, expanded и compact виды ItemHomeScreen.