### PR TITLE
fix: удалён Train.remoteObjectId + фильтрация маршрутов по месяцу

### DIFF
--- a/data_local/build.gradle.kts
+++ b/data_local/build.gradle.kts
@@ -77,7 +77,7 @@ sqldelight {
         create("RouteDatabase") {
             packageName.set("com.z_company.data_local.route.db")
             srcDirs.setFrom("src/commonMain/sqldelight/RouteDatabase")
-            version = 2
+            version = 3
             verifyMigrations.set(false)
         }
         create("SettingsDatabase") {

--- a/data_local/src/androidMain/kotlin/com/z_company/data_local/DatabaseDriverFactory.kt
+++ b/data_local/src/androidMain/kotlin/com/z_company/data_local/DatabaseDriverFactory.kt
@@ -33,8 +33,66 @@ actual class DatabaseDriverFactory(private val context: Context) {
         name = name,
         callback = object : AndroidSqliteDriver.Callback(schema) {
             override fun onDowngrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-                // Room использовал version 14+, SQLDelight начинает с version 1.
-                // При downgrade просто пропускаем — таблицы совместимы.
+                // Room использовал version 14+, SQLDelight начинает с version 1-3.
+                // Пересоздаём таблицы Train (без remoteObjectId) и Locomotive (nullable removeObjectId).
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS Train_new (
+                        trainId TEXT NOT NULL PRIMARY KEY,
+                        basicId TEXT NOT NULL,
+                        number TEXT,
+                        additionalNumbers TEXT DEFAULT NULL,
+                        distance TEXT DEFAULT '',
+                        weight TEXT,
+                        axle TEXT,
+                        conditionalLength TEXT,
+                        isHeavyLongDistance INTEGER NOT NULL DEFAULT 0,
+                        stations TEXT NOT NULL,
+                        servicePhase TEXT DEFAULT NULL,
+                        pusher TEXT DEFAULT NULL,
+                        doubleTraction TEXT DEFAULT NULL,
+                        doubledTrain TEXT DEFAULT NULL,
+                        FOREIGN KEY (basicId) REFERENCES BasicData(id) ON DELETE CASCADE ON UPDATE CASCADE
+                    )
+                """.trimIndent())
+                db.execSQL("""
+                    INSERT INTO Train_new (trainId, basicId, number, additionalNumbers, distance, weight, axle, conditionalLength, isHeavyLongDistance, stations, servicePhase, pusher, doubleTraction, doubledTrain)
+                    SELECT trainId, basicId, number, additionalNumbers, distance, weight, axle, conditionalLength, isHeavyLongDistance, stations, servicePhase, pusher, doubleTraction, doubledTrain
+                    FROM Train
+                """.trimIndent())
+                db.execSQL("DROP TABLE Train")
+                db.execSQL("ALTER TABLE Train_new RENAME TO Train")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_Train_basicId ON Train(basicId)")
+
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS Locomotive_new (
+                        locoId TEXT NOT NULL PRIMARY KEY,
+                        basicId TEXT NOT NULL,
+                        removeObjectId TEXT DEFAULT NULL,
+                        series TEXT,
+                        number TEXT,
+                        type INTEGER NOT NULL,
+                        electricSectionList TEXT NOT NULL,
+                        dieselSectionList TEXT NOT NULL,
+                        timeStartOfAcceptance INTEGER,
+                        timeEndOfAcceptance INTEGER,
+                        timeStartOfDelivery INTEGER,
+                        timeEndOfDelivery INTEGER,
+                        normaElectricCurrent1 INTEGER DEFAULT NULL,
+                        normaElectricCurrent2 INTEGER DEFAULT NULL,
+                        normaDiesel TEXT DEFAULT NULL,
+                        heatingCounterAccepted TEXT DEFAULT NULL,
+                        heatingCounterDelivery TEXT DEFAULT NULL,
+                        FOREIGN KEY (basicId) REFERENCES BasicData(id) ON DELETE CASCADE ON UPDATE CASCADE
+                    )
+                """.trimIndent())
+                db.execSQL("""
+                    INSERT INTO Locomotive_new (locoId, basicId, removeObjectId, series, number, type, electricSectionList, dieselSectionList, timeStartOfAcceptance, timeEndOfAcceptance, timeStartOfDelivery, timeEndOfDelivery, normaElectricCurrent1, normaElectricCurrent2, normaDiesel, heatingCounterAccepted, heatingCounterDelivery)
+                    SELECT locoId, basicId, CASE WHEN removeObjectId = '' THEN NULL ELSE removeObjectId END, series, number, type, electricSectionList, dieselSectionList, timeStartOfAcceptance, timeEndOfAcceptance, timeStartOfDelivery, timeEndOfDelivery, normaElectricCurrent1, normaElectricCurrent2, normaDiesel, heatingCounterAccepted, heatingCounterDelivery
+                    FROM Locomotive
+                """.trimIndent())
+                db.execSQL("DROP TABLE Locomotive")
+                db.execSQL("ALTER TABLE Locomotive_new RENAME TO Locomotive")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_Locomotive_basicId ON Locomotive(basicId)")
             }
         }
     )

--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/SqlDelightRouteRepository.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/SqlDelightRouteRepository.kt
@@ -74,7 +74,7 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
             db.locomotiveQueries.insertOrReplace(
                 locoId = loco.locoId,
                 basicId = locoBasicId,
-                removeObjectId = loco.remoteObjectId ?: "",
+                removeObjectId = loco.remoteObjectId,
                 series = loco.series,
                 number = loco.number,
                 type = loco.type.ordinal.toLong(),
@@ -96,7 +96,6 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
             db.trainQueries.insertOrReplace(
                 trainId = train.trainId,
                 basicId = trainBasicId,
-                remoteObjectId = train.remoteObjectId,
                 number = train.number,
                 additionalNumbers = TrainMapper.encodeAdditionalNumbers(train.additionalNumbers),
                 distance = train.distance,
@@ -293,7 +292,7 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
             db.locomotiveQueries.insertOrReplace(
                 locoId = locoId,
                 basicId = locomotive.basicId,
-                removeObjectId = locomotive.remoteObjectId ?: "",
+                removeObjectId = locomotive.remoteObjectId,
                 series = locomotive.series,
                 number = locomotive.number,
                 type = locomotive.type.ordinal.toLong(),
@@ -317,7 +316,6 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
             db.trainQueries.insertOrReplace(
                 trainId = train.trainId.ifBlank { generateId() },
                 basicId = train.basicId,
-                remoteObjectId = train.remoteObjectId,
                 number = train.number,
                 additionalNumbers = TrainMapper.encodeAdditionalNumbers(train.additionalNumbers),
                 distance = train.distance,
@@ -374,10 +372,6 @@ class SqlDelightRouteRepository : RouteRepository, KoinComponent {
 
     override fun setRemoteObjectIdLocomotive(locoId: String, remoteObjectId: String): Flow<ResultState<Unit>> {
         return flowRequest { db.locomotiveQueries.setRemoteObjectId(remoteObjectId, locoId) }
-    }
-
-    override fun setRemoteObjectIdTrain(trainId: String, remoteObjectId: String): Flow<ResultState<Unit>> {
-        return flowRequest { db.trainQueries.setRemoteObjectId(remoteObjectId, trainId) }
     }
 
     override fun setRemoteObjectIdPassenger(passengerId: String, objectId: String): Flow<ResultState<Unit>> {

--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/TrainMapper.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/TrainMapper.kt
@@ -74,7 +74,6 @@ internal object TrainMapper {
     fun toData(row: TrainRow): Train = Train(
         trainId = row.trainId,
         basicId = row.basicId,
-        remoteObjectId = row.remoteObjectId,
         number = row.number,
         additionalNumbers = decodeAdditionalNumbers(row.additionalNumbers),
         distance = row.distance,

--- a/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/2.sqm
+++ b/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/2.sqm
@@ -1,0 +1,60 @@
+-- Remove remoteObjectId from Train table
+CREATE TABLE IF NOT EXISTS Train_new (
+    trainId TEXT NOT NULL PRIMARY KEY,
+    basicId TEXT NOT NULL,
+    number TEXT,
+    additionalNumbers TEXT DEFAULT NULL,
+    distance TEXT DEFAULT '',
+    weight TEXT,
+    axle TEXT,
+    conditionalLength TEXT,
+    isHeavyLongDistance INTEGER NOT NULL DEFAULT 0,
+    stations TEXT NOT NULL,
+    servicePhase TEXT DEFAULT NULL,
+    pusher TEXT DEFAULT NULL,
+    doubleTraction TEXT DEFAULT NULL,
+    doubledTrain TEXT DEFAULT NULL,
+    FOREIGN KEY (basicId) REFERENCES BasicData(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO Train_new (trainId, basicId, number, additionalNumbers, distance, weight, axle, conditionalLength, isHeavyLongDistance, stations, servicePhase, pusher, doubleTraction, doubledTrain)
+SELECT trainId, basicId, number, additionalNumbers, distance, weight, axle, conditionalLength, isHeavyLongDistance, stations, servicePhase, pusher, doubleTraction, doubledTrain
+FROM Train;
+
+DROP TABLE Train;
+
+ALTER TABLE Train_new RENAME TO Train;
+
+CREATE INDEX IF NOT EXISTS index_Train_basicId ON Train(basicId);
+
+-- Fix Locomotive: removeObjectId NOT NULL -> nullable
+CREATE TABLE IF NOT EXISTS Locomotive_new (
+    locoId TEXT NOT NULL PRIMARY KEY,
+    basicId TEXT NOT NULL,
+    removeObjectId TEXT DEFAULT NULL,
+    series TEXT,
+    number TEXT,
+    type INTEGER NOT NULL,
+    electricSectionList TEXT NOT NULL,
+    dieselSectionList TEXT NOT NULL,
+    timeStartOfAcceptance INTEGER,
+    timeEndOfAcceptance INTEGER,
+    timeStartOfDelivery INTEGER,
+    timeEndOfDelivery INTEGER,
+    normaElectricCurrent1 INTEGER DEFAULT NULL,
+    normaElectricCurrent2 INTEGER DEFAULT NULL,
+    normaDiesel TEXT DEFAULT NULL,
+    heatingCounterAccepted TEXT DEFAULT NULL,
+    heatingCounterDelivery TEXT DEFAULT NULL,
+    FOREIGN KEY (basicId) REFERENCES BasicData(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO Locomotive_new (locoId, basicId, removeObjectId, series, number, type, electricSectionList, dieselSectionList, timeStartOfAcceptance, timeEndOfAcceptance, timeStartOfDelivery, timeEndOfDelivery, normaElectricCurrent1, normaElectricCurrent2, normaDiesel, heatingCounterAccepted, heatingCounterDelivery)
+SELECT locoId, basicId, CASE WHEN removeObjectId = '' THEN NULL ELSE removeObjectId END, series, number, type, electricSectionList, dieselSectionList, timeStartOfAcceptance, timeEndOfAcceptance, timeStartOfDelivery, timeEndOfDelivery, normaElectricCurrent1, normaElectricCurrent2, normaDiesel, heatingCounterAccepted, heatingCounterDelivery
+FROM Locomotive;
+
+DROP TABLE Locomotive;
+
+ALTER TABLE Locomotive_new RENAME TO Locomotive;
+
+CREATE INDEX IF NOT EXISTS index_Locomotive_basicId ON Locomotive(basicId);

--- a/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/BasicData.sq
+++ b/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/BasicData.sq
@@ -35,7 +35,7 @@ WHERE isDeleted = 0
     (timeStartWork >= :startPeriod AND timeStartWork <= :endPeriod)
     OR (timeEndWork >= :startPeriod AND timeEndWork <= :endPeriod)
     OR (timeStartWork <= :startPeriod AND timeEndWork >= :endPeriod)
-    OR (timeStartWork <= :endPeriod AND timeEndWork IS NULL)
+    OR (timeStartWork >= :startPeriod AND timeStartWork <= :endPeriod AND timeEndWork IS NULL)
   )
 ORDER BY timeStartWork DESC;
 

--- a/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/Locomotive.sq
+++ b/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/Locomotive.sq
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS Locomotive (
     locoId TEXT NOT NULL PRIMARY KEY,
     basicId TEXT NOT NULL,
-    removeObjectId TEXT NOT NULL,
+    removeObjectId TEXT DEFAULT NULL,
     series TEXT,
     number TEXT,
     type INTEGER NOT NULL,

--- a/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/Train.sq
+++ b/data_local/src/commonMain/sqldelight/RouteDatabase/com/z_company/data_local/route/db/Train.sq
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS Train (
     trainId TEXT NOT NULL PRIMARY KEY,
     basicId TEXT NOT NULL,
-    remoteObjectId TEXT DEFAULT NULL,
     number TEXT,
     additionalNumbers TEXT DEFAULT NULL,
     distance TEXT DEFAULT '',
@@ -20,11 +19,11 @@ CREATE TABLE IF NOT EXISTS Train (
 CREATE INDEX IF NOT EXISTS index_Train_basicId ON Train(basicId);
 
 insertOrReplace:
-INSERT OR REPLACE INTO Train (trainId, basicId, remoteObjectId, number, additionalNumbers, distance, weight, axle, conditionalLength, isHeavyLongDistance, stations, servicePhase, pusher, doubleTraction, doubledTrain)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO Train (trainId, basicId, number, additionalNumbers, distance, weight, axle, conditionalLength, isHeavyLongDistance, stations, servicePhase, pusher, doubleTraction, doubledTrain)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 update:
-UPDATE OR REPLACE Train SET trainId = :trainId, basicId = :basicId, remoteObjectId = :remoteObjectId, number = :number, additionalNumbers = :additionalNumbers, distance = :distance, weight = :weight, axle = :axle, conditionalLength = :conditionalLength, isHeavyLongDistance = :isHeavyLongDistance, stations = :stations, servicePhase = :servicePhase, pusher = :pusher, doubleTraction = :doubleTraction, doubledTrain = :doubledTrain
+UPDATE OR REPLACE Train SET trainId = :trainId, basicId = :basicId, number = :number, additionalNumbers = :additionalNumbers, distance = :distance, weight = :weight, axle = :axle, conditionalLength = :conditionalLength, isHeavyLongDistance = :isHeavyLongDistance, stations = :stations, servicePhase = :servicePhase, pusher = :pusher, doubleTraction = :doubleTraction, doubledTrain = :doubledTrain
 WHERE trainId = :trainId;
 
 getById:
@@ -35,9 +34,6 @@ SELECT * FROM Train WHERE basicId = :basicId;
 
 delete:
 DELETE FROM Train WHERE trainId = :trainId;
-
-setRemoteObjectId:
-UPDATE Train SET remoteObjectId = :remoteObjectId WHERE trainId = :trainId;
 
 countAll:
 SELECT COUNT(*) FROM Train;

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/Train.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/Train.kt
@@ -20,7 +20,6 @@ data class TrainAssist(
 data class Train(
     var trainId: String = generateId(),
     var basicId: String = "",
-    var remoteObjectId: String? = null,
     var number: String? = null,
     var additionalNumbers: MutableList<String> = mutableListOf(),
     var distance: String? = null,

--- a/domain/src/commonMain/kotlin/com/z_company/domain/repositories/RouteRepository.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/repositories/RouteRepository.kt
@@ -33,7 +33,6 @@ interface RouteRepository {
     fun setRemoteObjectIdRoute(basicId: String, remoteRouteId: String?): Flow<ResultState<Unit>>
     fun setRemoteObjectIdBasicData(basicId: String, remoteObjectId: String?): Flow<ResultState<Unit>>
     fun setRemoteObjectIdLocomotive(locoId: String, remoteObjectId: String): Flow<ResultState<Unit>>
-    fun setRemoteObjectIdTrain(trainId: String, remoteObjectId: String): Flow<ResultState<Unit>>
     fun setRemoteObjectIdPassenger(passengerId: String, objectId: String): Flow<ResultState<Unit>>
     fun setRemoteObjectIdPhoto(photoId: String, objectId: String): Flow<ResultState<Unit>>
     fun saveLocomotive(locomotive: Locomotive): Flow<ResultState<Unit>>

--- a/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
@@ -145,10 +145,6 @@ class RouteUseCase(private val repository: RouteRepository) {
         return repository.setRemoteObjectIdLocomotive(locoId, remoteObjectId)
     }
 
-    fun setRemoteObjectIdTrain(trainId: String, objectId: String): Flow<ResultState<Unit>> {
-        return repository.setRemoteObjectIdTrain(trainId, objectId)
-    }
-
     fun setRemoteObjectIdPassenger(passengerId: String, objectId: String): Flow<ResultState<Unit>> {
         return repository.setRemoteObjectIdPassenger(passengerId, objectId)
     }


### PR DESCRIPTION
1. Train.remoteObjectId: удалён из схемы, entity, маппера, репозитория. Миграция 2.sqm пересоздаёт таблицу Train без этого поля. Locomotive.removeObjectId: NOT NULL → nullable. onDowngrade в DatabaseDriverFactory обрабатывает переход с Room.

2. BasicData.sq getByPeriod: незавершённые маршруты (timeEndWork IS NULL) теперь показываются только в месяце начала работы, а не во всех последующих месяцах.