### PR TITLE
fix: виджет — текст отдыха в HomeViewModel, accent цвет, стиль кнопки…

### DIFF
--- a/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverWidget.kt
+++ b/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverWidget.kt
@@ -200,7 +200,7 @@ class LocoDriverWidget : GlanceAppWidget() {
                             Text(
                                 text = stateInfoLine1,
                                 style = TextStyle(
-                                    color = ColorProvider(WidgetColors.textPrimary),
+                                    color = ColorProvider(WidgetColors.accent),
                                     fontSize = 14.sp,
                                     fontWeight = FontWeight.Medium
                                 )
@@ -227,7 +227,7 @@ class LocoDriverWidget : GlanceAppWidget() {
                             )
                         }
                         if (nextReportText.isNotEmpty()) {
-                            Spacer(modifier = GlanceModifier.height(4.dp))
+                            Spacer(modifier = GlanceModifier.height(8.dp))
                             Text(
                                 text = nextReportText,
                                 style = TextStyle(
@@ -240,15 +240,15 @@ class LocoDriverWidget : GlanceAppWidget() {
                     }
 
                     // Right: play/stop button OR add button
-                    Box(
-                        modifier = GlanceModifier
-                            .width(90.dp)
-                            .cornerRadius(12.dp)
-                            .background(WidgetColors.buttonBackground)
-                            .padding(vertical = 4.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (hasCurrentRoute) {
+                    if (hasCurrentRoute) {
+                        Box(
+                            modifier = GlanceModifier
+                                .width(90.dp)
+                                .cornerRadius(12.dp)
+                                .background(WidgetColors.buttonBackground)
+                                .padding(vertical = 4.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
                             // Play/stop button with train info
                             Column(
                                 horizontalAlignment = Alignment.CenterHorizontally
@@ -297,15 +297,23 @@ class LocoDriverWidget : GlanceAppWidget() {
                                     )
                                 }
                             }
-                        } else {
-                            // Add route button
+                        }
+                    } else {
+                        // Add route button — light background, dark icon/text
+                        Box(
+                            modifier = GlanceModifier
+                                .width(90.dp)
+                                .cornerRadius(12.dp)
+                                .background(WidgetColors.addButtonBackground)
+                                .clickable(actionRunCallback<AddRouteActionCallback>())
+                                .padding(vertical = 4.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
                             Column(
-                                modifier = GlanceModifier
-                                    .clickable(actionRunCallback<AddRouteActionCallback>()),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 Image(
-                                    provider = ImageProvider(R.drawable.widget_add),
+                                    provider = ImageProvider(R.drawable.widget_add_dark),
                                     contentDescription = "Добавить маршрут",
                                     modifier = GlanceModifier.size(40.dp)
                                 )
@@ -313,14 +321,14 @@ class LocoDriverWidget : GlanceAppWidget() {
                                 Text(
                                     text = "Добавить",
                                     style = TextStyle(
-                                        color = ColorProvider(WidgetColors.textSecondary),
+                                        color = ColorProvider(WidgetColors.addButtonText),
                                         fontSize = 10.sp
                                     )
                                 )
                                 Text(
                                     text = "маршрут",
                                     style = TextStyle(
-                                        color = ColorProvider(WidgetColors.textSecondary),
+                                        color = ColorProvider(WidgetColors.addButtonText),
                                         fontSize = 10.sp
                                     )
                                 )
@@ -340,6 +348,8 @@ class LocoDriverWidget : GlanceAppWidget() {
         val textSecondary = Color(0xFFEBE8E8)       // DarkOnSurface
         val accent = Color(0xFF92b2e5)              // DarkTertiary
         val overtimeColor = Color(0xFFeb9e9e)       // DarkError — for overtime indicator
+        val addButtonBackground = Color(0xDDf0f0f0) // Light background for "Добавить" button
+        val addButtonText = Color(0xFF333333)        // Dark text for "Добавить" button
     }
 
     /** Preference keys */

--- a/app/src/main/res/drawable/widget_add_dark.xml
+++ b/app/src/main/res/drawable/widget_add_dark.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#333333">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6z" />
+</vector>

--- a/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/home_view_model/HomeViewModel.kt
@@ -953,20 +953,20 @@ class HomeViewModel : ViewModel(), KoinComponent {
                 val minTime = userSettings.minTimeRestPointOfTurnover
                 val shortRest = maxOf(workTime / 2, minTime)
                 val fullRest = maxOf(workTime, minTime)
-                val line1 =
+                val shortLine =
                     "Короткий ${ConverterLongToTime.formatDurationFromMillis(shortRest)} до ${dateAndTimeConverter.getDateMiniAndTime(endWork + shortRest)}"
-                val line2 =
+                val fullLine =
                     "Полный ${ConverterLongToTime.formatDurationFromMillis(fullRest)} до ${dateAndTimeConverter.getDateMiniAndTime(endWork + fullRest)}"
-                return Triple(line1, line2, "")
+                return Triple("Отдых в ПО", shortLine, fullLine)
             } else {
                 // Home rest (simplified — single route, no chain)
                 val rawDuration = (workTime.toDouble() * 2.6).toLong()
                 val duration = maxOf(rawDuration, userSettings.minTimeHomeRest)
                 val endRestTime = endWork + duration
-                val line1 =
+                val durationLine =
                     "Продлится ${ConverterLongToTime.formatDurationFromMillis(duration)}"
-                val line2 = "До ${dateAndTimeConverter.getDateMiniAndTime(endRestTime)}"
-                return Triple(line1, line2, "")
+                val endLine = "До ${dateAndTimeConverter.getDateMiniAndTime(endRestTime)}"
+                return Triple("Домашний отдых", durationLine, endLine)
             }
         }
 


### PR DESCRIPTION
… «Добавить»

- HomeViewModel.computeStateInfo: добавлен заголовок "Отдых в ПО"/"Домашний отдых" в line1 (был баг — после изменения типа отдыха текст пропадал, оставались только расчёты)
- stateInfoLine1 цвет → accent (tertiary) для выделения заголовка
- Отступ перед "Следующая явка" увеличен 4dp → 8dp
- Кнопка «Добавить маршрут»: светлый фон, тёмные иконка и текст