### PR TITLE
feat: авто-масштабирование текста виджетов через AndroidRemoteViews

### DIFF
--- a/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverSmallWidget.kt
+++ b/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverSmallWidget.kt
@@ -1,38 +1,39 @@
 package com.z_company.loco_driver.widget
 
 import android.content.Context
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
 import android.util.Log
+import android.widget.RemoteViews
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.action.clickable
+import androidx.glance.appwidget.AndroidRemoteViews
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
 import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.ImageProvider
 import androidx.glance.background
 import androidx.glance.currentState
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
-import androidx.glance.layout.Column
-import androidx.glance.layout.Row
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
-import androidx.glance.text.FontWeight
-import androidx.glance.text.Text
-import androidx.glance.text.TextStyle
-import androidx.glance.unit.ColorProvider
 import com.z_company.loco_driver.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -66,6 +67,11 @@ class LocoDriverSmallWidget : GlanceAppWidget() {
         val totalTimeText = prefs[Keys.TOTAL_TIME_TEXT] ?: "--:--"
         val normHours = prefs[Keys.NORM_HOURS] ?: ""
 
+        val context = LocalContext.current
+        val remoteViews = RemoteViews(context.packageName, R.layout.widget_small_autosize).apply {
+            setTextViewText(R.id.time_norm_text, buildTimeNormSpan(totalTimeText, normHours))
+        }
+
         Box(
             modifier = GlanceModifier
                 .fillMaxSize()
@@ -75,47 +81,40 @@ class LocoDriverSmallWidget : GlanceAppWidget() {
                 .padding(horizontal = 12.dp, vertical = 8.dp),
             contentAlignment = Alignment.Center
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Row(
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    Text(
-                        text = totalTimeText,
-                        style = TextStyle(
-                            color = ColorProvider(Colors.textPrimary),
-                            fontSize = 26.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    )
-                    if (normHours.isNotEmpty()) {
-                        Text(
-                            text = " / $normHours",
-                            style = TextStyle(
-                                color = ColorProvider(Colors.accent),
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Medium
-                            )
-                        )
-                    }
-                }
-                Text(
-                    text = "Отработано / норма",
-                    style = TextStyle(
-                        color = ColorProvider(Colors.textSecondary),
-                        fontSize = 10.sp
-                    )
-                )
-            }
+            AndroidRemoteViews(
+                remoteViews = remoteViews,
+                modifier = GlanceModifier.fillMaxSize()
+            )
         }
     }
 
-    private object Colors {
-        val background = Color(0xE6333333)
-        val textPrimary = Color(0xFFf0f0f0)
-        val textSecondary = Color(0xFFEBE8E8)
-        val accent = Color(0xFF92b2e5)
+    /** Build SpannableString: "164:30" (white, bold, 32sp) + " / 176ч" (accent, 16sp) */
+    private fun buildTimeNormSpan(totalTimeText: String, normHours: String): CharSequence {
+        val builder = SpannableStringBuilder()
+        builder.append(totalTimeText)
+        builder.setSpan(
+            ForegroundColorSpan(0xFFf0f0f0.toInt()),
+            0, totalTimeText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        builder.setSpan(
+            StyleSpan(Typeface.BOLD),
+            0, totalTimeText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        if (normHours.isNotEmpty()) {
+            val normStart = builder.length
+            builder.append(" / $normHours")
+            builder.setSpan(
+                ForegroundColorSpan(0xFF92b2e5.toInt()),
+                normStart, builder.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            builder.setSpan(
+                RelativeSizeSpan(0.5f),
+                normStart, builder.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+
+        return builder
     }
 
     object Keys {

--- a/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverWidget.kt
+++ b/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverWidget.kt
@@ -2,7 +2,15 @@ package com.z_company.loco_driver.widget
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
 import android.util.Log
+import android.view.View
+import android.widget.RemoteViews
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -21,9 +29,11 @@ import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.action.ActionCallback
 import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.AndroidRemoteViews
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
 import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.LocalContext
 import androidx.glance.background
 import androidx.glance.currentState
 import androidx.glance.layout.Alignment
@@ -118,70 +128,12 @@ class LocoDriverWidget : GlanceAppWidget() {
                 modifier = GlanceModifier.fillMaxSize()
             ) {
                 // ─── Top: work time / norm (left) + remaining (right) ───
-                Row(
-                    modifier = GlanceModifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    // Left: work time / norm
-                    Column(
-                        modifier = GlanceModifier.defaultWeight()
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.Bottom
-                        ) {
-                            Text(
-                                text = totalTimeText,
-                                style = TextStyle(
-                                    color = ColorProvider(WidgetColors.textPrimary),
-                                    fontSize = 36.sp,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            )
-                            if (normHours.isNotEmpty()) {
-                                Text(
-                                    text = " / $normHours",
-                                    style = TextStyle(
-                                        color = ColorProvider(WidgetColors.accent),
-                                        fontSize = 18.sp,
-                                        fontWeight = FontWeight.Medium
-                                    )
-                                )
-                            }
-                        }
-                        Text(
-                            text = "Отработано / норма",
-                            style = TextStyle(
-                                color = ColorProvider(WidgetColors.textSecondary),
-                                fontSize = 12.sp
-                            )
-                        )
-                    }
-
-                    // Right: remaining to norm / overtime
-                    if (normRemainingText.isNotEmpty()) {
-                        Column(
-                            horizontalAlignment = Alignment.End
-                        ) {
-                            Text(
-                                text = normRemainingText,
-                                style = TextStyle(
-                                    color = ColorProvider(
-                                        if (isOvertime) WidgetColors.overtimeColor else WidgetColors.accent
-                                    ),
-                                    fontSize = 18.sp,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            )
-                            Text(
-                                text = if (isOvertime) "переработка" else "до нормы",
-                                style = TextStyle(
-                                    color = ColorProvider(WidgetColors.textSecondary),
-                                    fontSize = 12.sp
-                                )
-                            )
-                        }
-                    }
-                }
+                AutoSizedTopRow(
+                    totalTimeText = totalTimeText,
+                    normHours = normHours,
+                    normRemainingText = normRemainingText,
+                    isOvertime = isOvertime
+                )
 
                 // Spacer pushes bottom section to the bottom edge
                 Spacer(modifier = GlanceModifier.defaultWeight())
@@ -202,7 +154,8 @@ class LocoDriverWidget : GlanceAppWidget() {
                                     color = ColorProvider(WidgetColors.accent),
                                     fontSize = 14.sp,
                                     fontWeight = FontWeight.Medium
-                                )
+                                ),
+                                maxLines = 1
                             )
                         }
                         if (stateInfoLine2.isNotEmpty()) {
@@ -212,7 +165,8 @@ class LocoDriverWidget : GlanceAppWidget() {
                                     color = ColorProvider(WidgetColors.textPrimary),
                                     fontSize = 14.sp,
                                     fontWeight = FontWeight.Medium
-                                )
+                                ),
+                                maxLines = 1
                             )
                         }
                         if (stateInfoLine3.isNotEmpty()) {
@@ -222,7 +176,8 @@ class LocoDriverWidget : GlanceAppWidget() {
                                     color = ColorProvider(WidgetColors.textPrimary),
                                     fontSize = 14.sp,
                                     fontWeight = FontWeight.Medium
-                                )
+                                ),
+                                maxLines = 1
                             )
                         }
                         if (nextReportText.isNotEmpty()) {
@@ -233,7 +188,8 @@ class LocoDriverWidget : GlanceAppWidget() {
                                     color = ColorProvider(WidgetColors.accent),
                                     fontSize = 13.sp,
                                     fontWeight = FontWeight.Medium
-                                )
+                                ),
+                                maxLines = 1
                             )
                         }
                     }
@@ -274,7 +230,8 @@ class LocoDriverWidget : GlanceAppWidget() {
                                             color = ColorProvider(WidgetColors.addButtonText),
                                             fontSize = 10.sp,
                                             fontWeight = FontWeight.Medium
-                                        )
+                                        ),
+                                        maxLines = 1
                                     )
                                 }
                                 if (statusText.isNotEmpty()) {
@@ -337,6 +294,69 @@ class LocoDriverWidget : GlanceAppWidget() {
                 }
             }
         }
+    }
+
+    /** Auto-sized top row using AndroidRemoteViews with autoSizeTextType */
+    @Composable
+    private fun AutoSizedTopRow(
+        totalTimeText: String,
+        normHours: String,
+        normRemainingText: String,
+        isOvertime: Boolean
+    ) {
+        val context = LocalContext.current
+        val remoteViews = RemoteViews(context.packageName, R.layout.widget_autosize_top_row).apply {
+            // Build spannable for time + norm
+            setTextViewText(R.id.time_norm_text, buildTimeNormSpan(totalTimeText, normHours))
+
+            // Remaining / overtime
+            if (normRemainingText.isNotEmpty()) {
+                val remainingColor = if (isOvertime) 0xFFeb9e9e.toInt() else 0xFF92b2e5.toInt()
+                setTextViewText(R.id.remaining_text, normRemainingText)
+                setTextColor(R.id.remaining_text, remainingColor)
+
+                val labelText = if (isOvertime) "переработка" else "до нормы"
+                setTextViewText(R.id.remaining_label, labelText)
+
+                setViewVisibility(R.id.remaining_container, View.VISIBLE)
+            } else {
+                setViewVisibility(R.id.remaining_container, View.GONE)
+            }
+        }
+
+        AndroidRemoteViews(
+            remoteViews = remoteViews,
+            modifier = GlanceModifier.fillMaxWidth()
+        )
+    }
+
+    /** Build SpannableString: "164:30" (white, bold, 44sp) + " / 176ч" (accent, 22sp) */
+    private fun buildTimeNormSpan(totalTimeText: String, normHours: String): CharSequence {
+        val builder = SpannableStringBuilder()
+        builder.append(totalTimeText)
+        builder.setSpan(
+            ForegroundColorSpan(0xFFf0f0f0.toInt()),
+            0, totalTimeText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        builder.setSpan(
+            StyleSpan(Typeface.BOLD),
+            0, totalTimeText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        if (normHours.isNotEmpty()) {
+            val normStart = builder.length
+            builder.append(" / $normHours")
+            builder.setSpan(
+                ForegroundColorSpan(0xFF92b2e5.toInt()),
+                normStart, builder.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            builder.setSpan(
+                RelativeSizeSpan(0.5f),
+                normStart, builder.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+
+        return builder
     }
 
     /** Widget color palette — matches app dark theme (Color.kt) */

--- a/app/src/main/res/layout/widget_autosize_top_row.xml
+++ b/app/src/main/res/layout/widget_autosize_top_row.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="bottom">
+
+    <!-- Left column: time + norm -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_weight="7"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/time_norm_text"
+            android:layout_width="match_parent"
+            android:layout_height="54dp"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="18sp"
+            android:autoSizeMaxTextSize="44sp"
+            android:autoSizeStepGranularity="1sp"
+            android:maxLines="1"
+            android:gravity="bottom|start"
+            android:includeFontPadding="false" />
+
+        <TextView
+            android:id="@+id/time_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Отработано / норма"
+            android:textColor="#EBE8E8"
+            android:textSize="12sp"
+            android:maxLines="1" />
+    </LinearLayout>
+
+    <!-- Right column: remaining / overtime -->
+    <LinearLayout
+        android:id="@+id/remaining_container"
+        android:layout_width="0dp"
+        android:layout_weight="3"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="end">
+
+        <TextView
+            android:id="@+id/remaining_text"
+            android:layout_width="match_parent"
+            android:layout_height="28dp"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="10sp"
+            android:autoSizeMaxTextSize="22sp"
+            android:autoSizeStepGranularity="1sp"
+            android:maxLines="1"
+            android:gravity="bottom|end"
+            android:textStyle="bold"
+            android:includeFontPadding="false" />
+
+        <TextView
+            android:id="@+id/remaining_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#EBE8E8"
+            android:textSize="12sp"
+            android:maxLines="1"
+            android:layout_gravity="end" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/widget_preview.xml
+++ b/app/src/main/res/layout/widget_preview.xml
@@ -37,7 +37,7 @@
                         android:maxLines="1"
                         android:text="164:30"
                         android:textColor="#f0f0f0"
-                        android:textSize="36sp"
+                        android:textSize="44sp"
                         android:textStyle="bold" />
 
                     <TextView
@@ -46,7 +46,7 @@
                         android:maxLines="1"
                         android:text=" / 176ч"
                         android:textColor="#92b2e5"
-                        android:textSize="18sp" />
+                        android:textSize="22sp" />
                 </LinearLayout>
 
                 <TextView

--- a/app/src/main/res/layout/widget_small_autosize.xml
+++ b/app/src/main/res/layout/widget_small_autosize.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center">
+
+    <TextView
+        android:id="@+id/time_norm_text"
+        android:layout_width="match_parent"
+        android:layout_height="42dp"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="12sp"
+        android:autoSizeMaxTextSize="32sp"
+        android:autoSizeStepGranularity="1sp"
+        android:maxLines="1"
+        android:gravity="center"
+        android:includeFontPadding="false" />
+
+    <TextView
+        android:id="@+id/time_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Отработано / норма"
+        android:textColor="#EBE8E8"
+        android:textSize="10sp"
+        android:maxLines="1" />
+</LinearLayout>

--- a/app/src/main/res/layout/widget_small_preview.xml
+++ b/app/src/main/res/layout/widget_small_preview.xml
@@ -20,7 +20,7 @@
             android:maxLines="1"
             android:text="164:30"
             android:textColor="#f0f0f0"
-            android:textSize="26sp"
+            android:textSize="32sp"
             android:textStyle="bold" />
 
         <TextView
@@ -29,7 +29,7 @@
             android:maxLines="1"
             android:text=" / 176ч"
             android:textColor="#92b2e5"
-            android:textSize="14sp" />
+            android:textSize="16sp" />
     </LinearLayout>
 
     <TextView


### PR DESCRIPTION
autoSizeTextType=uniform для времени/нормы/остатка — текст автоматически уменьшается при увеличении системного шрифта. SpannableString для комбинации времени и нормы в одном TextView. maxLines=1 для остальных текстов. Исходные размеры шрифтов восстановлены (44/22sp, 32/16sp).