### PR TITLE
fix: ограничение высоты AndroidRemoteViews верхней секции виджета

### DIFF
--- a/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverWidget.kt
+++ b/app/src/main/java/com/z_company/loco_driver/widget/LocoDriverWidget.kt
@@ -326,7 +326,7 @@ class LocoDriverWidget : GlanceAppWidget() {
 
         AndroidRemoteViews(
             remoteViews = remoteViews,
-            modifier = GlanceModifier.fillMaxWidth()
+            modifier = GlanceModifier.fillMaxWidth().height(78.dp)
         )
     }
 


### PR DESCRIPTION
AndroidRemoteViews без height занимал всё пространство Column, скрывая нижнюю секцию (state info + кнопки). Добавлено height(78.dp).