### PR TITLE
feat: UI-доработки перерыва — перенос под Сдачу, валидация, фильтр, и…

### DIFF
--- a/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
@@ -192,6 +192,31 @@ class RouteUseCase(private val repository: RouteRepository) {
                     )
                 )
             }
+            val breakStart = route.basicData.timeStartBreak
+            val breakEnd = route.basicData.timeEndBreak
+            if (breakStart != null && breakEnd != null) {
+                if (breakStart >= breakEnd) {
+                    trySend(
+                        ResultState.Error(
+                            ErrorEntity(message = "Начало перерыва позже или равно окончанию.")
+                        )
+                    )
+                }
+                if (startTime != null && breakStart < startTime) {
+                    trySend(
+                        ResultState.Error(
+                            ErrorEntity(message = "Начало перерыва раньше явки.")
+                        )
+                    )
+                }
+                if (endTime != null && breakEnd > endTime) {
+                    trySend(
+                        ResultState.Error(
+                            ErrorEntity(message = "Окончание перерыва позже сдачи.")
+                        )
+                    )
+                }
+            }
             trySend(ResultState.Success(Unit))
             awaitClose()
         }

--- a/features/route/src/main/java/com/z_company/route/component/ItemHomeScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/component/ItemHomeScreen.kt
@@ -58,6 +58,7 @@ import com.z_company.core.ui.component.AutoSizeText
 import com.z_company.core.ui.theme.Shapes
 import com.z_company.core.util.ConverterLongToTime
 import com.z_company.core.util.DateAndTimeConverter
+import com.z_company.domain.entities.route.UtilsForEntities.getBreakDuration
 import com.z_company.domain.entities.route.UtilsForEntities.getPassengerTime
 import com.z_company.domain.entities.route.UtilsForEntities.getWorkTime
 import com.z_company.route.R
@@ -565,6 +566,14 @@ fun ItemHomeScreen(
                                     Image(
                                         modifier = Modifier.size(20.dp),
                                         painter = painterResource(id = R.drawable.icon_holiday),
+                                        contentDescription = null
+                                    )
+                                }
+                                if (route.getBreakDuration() > 0L) {
+                                    Icon(
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(20.dp),
+                                        painter = painterResource(id = R.drawable.pause_24px),
                                         contentDescription = null
                                     )
                                 }

--- a/features/route/src/main/java/com/z_company/route/ui/AllRouteScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/AllRouteScreen.kt
@@ -725,5 +725,19 @@ private fun FiltersRow(selected: Set<RouteFilter>, onToggle: (RouteFilter) -> Un
             },
             label = "Длинные поезда"
         )
+
+        ChipApp(
+            selected = selected.contains(RouteFilter.HAS_BREAK),
+            onClick = { onToggle(RouteFilter.HAS_BREAK) },
+            leading = {
+                Icon(
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                    painter = painterResource(id = R.drawable.pause_24px),
+                    contentDescription = null
+                )
+            },
+            label = "С перерывами"
+        )
     }
 }

--- a/features/route/src/main/java/com/z_company/route/ui/FormScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormScreen.kt
@@ -93,6 +93,7 @@ import com.z_company.domain.entities.route.Locomotive
 import com.z_company.domain.entities.route.Passenger
 import com.z_company.domain.entities.route.Route
 import com.z_company.domain.entities.route.Train
+import com.z_company.domain.entities.route.UtilsForEntities.getBreakDuration
 import com.z_company.domain.entities.route.UtilsForEntities.getPassengerTime
 import com.z_company.domain.entities.route.UtilsForEntities.getWorkTime
 import com.z_company.domain.util.minus
@@ -656,7 +657,8 @@ fun FormScreen(
                 ) {
                     val startTimeInLong = route.basicData.timeStartWork
                     val endTimeInLong = route.basicData.timeEndWork
-                    val workTimeInLong = endTimeInLong - startTimeInLong
+                    val breakDuration = route.getBreakDuration()
+                    val workTimeInLong = (endTimeInLong - startTimeInLong)?.let { it - breakDuration }
                     val workTimeInFormatted =
                         viewModel.convertTimeToStringFormat(workTimeInLong)
 
@@ -732,35 +734,41 @@ fun FormScreen(
                                     ) {
                                         val holidayTime by viewModel.holidayTime.collectAsState()
 
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-                                            Icon(
-                                                modifier = Modifier
-                                                    .size(32.dp)
-                                                    .padding(end = 4.dp),
-                                                painter = painterResource(id = R.drawable.dark_mode_24px),
-                                                contentDescription = null,
-                                                tint = MaterialTheme.colorScheme.primary
-                                            )
-                                            Text(
-                                                text = viewModel.convertTimeToStringFormat(nightTime),
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.primary
-                                            )
+                                        if (nightTime != null && nightTime > 0L) {
+                                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                                Icon(
+                                                    modifier = Modifier
+                                                        .size(32.dp)
+                                                        .padding(end = 4.dp),
+                                                    painter = painterResource(id = R.drawable.dark_mode_24px),
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.primary
+                                                )
+                                                Text(
+                                                    text = viewModel.convertTimeToStringFormat(nightTime),
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                            }
                                         }
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-                                            Icon(
-                                                modifier = Modifier
-                                                    .size(32.dp)
-                                                    .padding(end = 4.dp),
-                                                painter = painterResource(id = R.drawable.passenger_24px),
-                                                contentDescription = null,
-                                                tint = MaterialTheme.colorScheme.primary
-                                            )
-                                            Text(
-                                                text = viewModel.convertTimeToStringFormat(route.getPassengerTime()),
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.primary
-                                            )
+                                        route.getPassengerTime()?.let { passengerTime ->
+                                            if (passengerTime > 0L) {
+                                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                                    Icon(
+                                                        modifier = Modifier
+                                                            .size(32.dp)
+                                                            .padding(end = 4.dp),
+                                                        painter = painterResource(id = R.drawable.passenger_24px),
+                                                        contentDescription = null,
+                                                        tint = MaterialTheme.colorScheme.primary
+                                                    )
+                                                    Text(
+                                                        text = viewModel.convertTimeToStringFormat(passengerTime),
+                                                        style = MaterialTheme.typography.bodyMedium,
+                                                        color = MaterialTheme.colorScheme.primary
+                                                    )
+                                                }
+                                            }
                                         }
 
                                         holidayTime?.let { time ->
@@ -1224,6 +1232,64 @@ fun FormScreen(
                                 }
                             }
 
+                            val animatedBackgroundColorsEndWork by animateColorAsState(
+                                targetValue = if (route.basicData.timeEndWork == null) MaterialTheme.colorScheme.surface
+                                else MaterialTheme.colorScheme.secondary,
+                                animationSpec = tween(
+                                    durationMillis = 200,
+                                    easing = FastOutSlowInEasing
+                                )
+                            )
+
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .shadow(elevation = 2.dp, shape = Shapes.medium)
+                                    .background(
+                                        color = animatedBackgroundColorsEndWork,
+                                        shape = Shapes.medium
+                                    )
+                                    .combinedClickable(
+                                        onClick = {
+                                            showEndDatePicker = true
+                                        },
+                                        onLongClick = {
+                                            endTimeInLong?.let {
+                                                showBottomSheetRemoveTimeEndWork = true
+                                            }
+                                        }
+                                    )
+                                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = "Сдача",
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                    style = LocalTextStyle.current.copy(
+                                        fontWeight = FontWeight.Light
+                                    )
+                                )
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                                ) {
+                                    var textColor =
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+
+                                    val dateAndTimeEndText = endTimeInLong?.let {
+                                        textColor = MaterialTheme.colorScheme.primary
+                                        dateAndTimeConverter?.getDateAndTime(
+                                            endTimeInLong
+                                        )
+                                    } ?: ""
+                                    Text(
+                                        text = dateAndTimeEndText,
+                                        color = textColor,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                    )
+                                }
+                            }
+
                             // Перерыв
                             if (isShowBreak) {
                                 TextButton(
@@ -1377,64 +1443,6 @@ fun FormScreen(
                                             }
                                         }
                                     }
-                                }
-                            }
-
-                            val animatedBackgroundColorsEndWork by animateColorAsState(
-                                targetValue = if (route.basicData.timeEndWork == null) MaterialTheme.colorScheme.surface
-                                else MaterialTheme.colorScheme.secondary,
-                                animationSpec = tween(
-                                    durationMillis = 200,
-                                    easing = FastOutSlowInEasing
-                                )
-                            )
-
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .shadow(elevation = 2.dp, shape = Shapes.medium)
-                                    .background(
-                                        color = animatedBackgroundColorsEndWork,
-                                        shape = Shapes.medium
-                                    )
-                                    .combinedClickable(
-                                        onClick = {
-                                            showEndDatePicker = true
-                                        },
-                                        onLongClick = {
-                                            endTimeInLong?.let {
-                                                showBottomSheetRemoveTimeEndWork = true
-                                            }
-                                        }
-                                    )
-                                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = "Сдача",
-                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
-                                    style = LocalTextStyle.current.copy(
-                                        fontWeight = FontWeight.Light
-                                    )
-                                )
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(16.dp)
-                                ) {
-                                    var textColor =
-                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
-
-                                    val dateAndTimeEndText = endTimeInLong?.let {
-                                        textColor = MaterialTheme.colorScheme.primary
-                                        dateAndTimeConverter?.getDateAndTime(
-                                            endTimeInLong
-                                        )
-                                    } ?: ""
-                                    Text(
-                                        text = dateAndTimeEndText,
-                                        color = textColor,
-                                        style = MaterialTheme.typography.bodyLarge,
-                                    )
                                 }
                             }
                         }

--- a/features/route/src/main/java/com/z_company/route/ui/SettingsScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/SettingsScreen.kt
@@ -1127,7 +1127,8 @@ fun SettingsScreen(
                                         shape = Shapes.medium
                                     )
                                     .padding(horizontal = 16.dp, vertical = 12.dp),
-                                horizontalArrangement = Arrangement.SpaceBetween
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Text(
                                     modifier = Modifier
@@ -1172,7 +1173,8 @@ fun SettingsScreen(
                                         shape = Shapes.medium
                                     )
                                     .padding(horizontal = 16.dp, vertical = 12.dp),
-                                horizontalArrangement = Arrangement.SpaceBetween
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Text(
                                     modifier = Modifier

--- a/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/all_route_view_model/AllRouteViewModel.kt
@@ -21,6 +21,7 @@ import com.z_company.core.ui.snackbar.ISnackbarManager
 import com.z_company.core.util.ConverterLongToTime
 import com.z_company.core.util.DateAndTimeConverter
 import com.z_company.domain.entities.route.Route
+import com.z_company.domain.entities.route.UtilsForEntities.getBreakDuration
 import com.z_company.domain.entities.route.UtilsForEntities.getLongDistanceTime
 import com.z_company.domain.entities.route.UtilsForEntities.isExtendedServicePhaseTrains
 import com.z_company.domain.entities.route.UtilsForEntities.isHeavyTrains
@@ -52,7 +53,8 @@ enum class RouteFilter {
     FOLLOWING_RESERVE,
     ONE_PERSON,
     OVER_12_HOURS,
-    LONG_TRAINS
+    LONG_TRAINS,
+    HAS_BREAK
 }
 
 data class RoutesUiState(
@@ -566,6 +568,9 @@ class AllRouteViewModel(application: Application) : AndroidViewModel(application
                 val start = routeState.route.basicData?.timeStartWork ?: 0L
                 val end = routeState.route.basicData?.timeEndWork ?: 0L
                 ok = ok && (end > start && (end - start) > over12hMillis)
+            }
+            if (filters.contains(RouteFilter.HAS_BREAK)) {
+                ok = ok && (routeState.route.getBreakDuration() > 0L)
             }
             ok
         }


### PR DESCRIPTION
…конка

- FormScreen: перерыв перемещён под поле Сдача
- FormScreen: рабочее время вверху учитывает перерыв
- FormScreen: скрытие нулевых ночных/пассажиров
- RouteUseCase: валидация перерыва в isValidBasicData()
- ItemHomeScreen: иконка pause_24px для маршрутов с перерывом
- AllRouteScreen: фильтр «С перерывами» (HAS_BREAK)
- SettingsScreen: вертикальное центрирование Switch секций