### PR TITLE
feat: tooltip перерыва в ItemHomeScreen, иконка ⓘ с подсказкой, вырав…

### DIFF
--- a/features/route/src/main/java/com/z_company/route/component/ItemHomeScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/component/ItemHomeScreen.kt
@@ -407,6 +407,30 @@ fun ItemHomeScreen(
                                             Icon(
                                                 tint = MaterialTheme.colorScheme.primary,
                                                 modifier = Modifier.size(20.dp),
+                                                painter = painterResource(id = R.drawable.pause_24px),
+                                                contentDescription = null
+                                            )
+                                            Text(
+                                                overflow = TextOverflow.Visible,
+                                                text = " - ",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.primary,
+                                            )
+                                            Text(
+                                                overflow = TextOverflow.Visible,
+                                                text = "Перерыв в работе",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.primary,
+                                            )
+                                        }
+                                    }
+                                    item {
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Icon(
+                                                tint = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.size(20.dp),
                                                 painter = painterResource(id = R.drawable.long_distance_24px),
                                                 contentDescription = null
                                             )

--- a/features/route/src/main/java/com/z_company/route/ui/FormScreen.kt
+++ b/features/route/src/main/java/com/z_company/route/ui/FormScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.BasicTooltipBox
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -29,6 +31,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
@@ -47,6 +50,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -1292,14 +1296,58 @@ fun FormScreen(
 
                             // Перерыв
                             if (isShowBreak) {
-                                TextButton(
-                                    onClick = { isBreakFieldsVisible = !isBreakFieldsVisible }
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Text(
-                                        text = "Перерыв",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.tertiary
-                                    )
+                                    TextButton(
+                                        onClick = { isBreakFieldsVisible = !isBreakFieldsVisible }
+                                    ) {
+                                        Text(
+                                            text = "Перерыв",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.tertiary
+                                        )
+                                    }
+
+                                    val breakTooltipState = rememberBasicTooltipState()
+                                    val breakTooltipScope = rememberCoroutineScope()
+
+                                    BasicTooltipBox(
+                                        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                                        tooltip = {
+                                            Text(
+                                                modifier = Modifier
+                                                    .background(
+                                                        shape = Shapes.medium,
+                                                        color = MaterialTheme.colorScheme.surface
+                                                    )
+                                                    .padding(
+                                                        horizontal = 12.dp,
+                                                        vertical = 8.dp
+                                                    ),
+                                                text = "Время перерыва не учитывается при расчёте рабочего времени",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.primary
+                                            )
+                                        },
+                                        state = breakTooltipState
+                                    ) {
+                                        IconButton(
+                                            modifier = Modifier.size(24.dp),
+                                            onClick = {
+                                                breakTooltipScope.launch {
+                                                    breakTooltipState.show(MutatePriority.Default)
+                                                }
+                                            }
+                                        ) {
+                                            Icon(
+                                                modifier = Modifier.size(18.dp),
+                                                painter = painterResource(id = R.drawable.info_24px),
+                                                tint = MaterialTheme.colorScheme.tertiary,
+                                                contentDescription = "Подсказка"
+                                            )
+                                        }
+                                    }
                                 }
 
                                 AnimatedVisibility(visible = isBreakFieldsVisible) {
@@ -1453,7 +1501,7 @@ fun FormScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .animateItem()
-                                .padding(bottom = 32.dp, top = 16.dp),
+                                .padding(bottom = 32.dp, top = 8.dp),
                             horizontalAlignment = Alignment.End,
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {


### PR DESCRIPTION
…нивание отступов

- ItemHomeScreen: tooltip «Перерыв в работе» при длинном нажатии на иконки
- FormScreen: иконка info_24px рядом с «Перерыв» → tooltip «Время перерыва не учитывается при расчёте рабочего времени»
- FormScreen: уменьшен top padding (16dp → 8dp) между перерывом и секциями поезд/локомотив