### PR TITLE
fix: wrap data_local Koin modules for iOS Swift visibility

### DIFF
--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -6,13 +6,11 @@ struct iOSApp: App {
 
     init() {
         // Инициализируем Koin перед стартом UI.
-        // Передаём модули data_local (SQLDelight) и domain (UseCases).
-        // Модуль data_remote (iosRepositoryModule) регистрируется внутри initKoin().
-        IosKoinHelperKt.doInitKoin(additionalModules: [
-            SqlDelightRouteModuleKt.sqlDelightRouteModule,       // RouteDatabase, SearchResponseDatabase
-            SqlDelightSettingModuleKt.sqlDelightSettingsModule,  // SettingsDatabase, SalarySettingDatabase
-            IosUseCaseModuleKt.iosUseCaseModule,                 // Repositories, UseCases, iOS ViewModels
-        ])
+        // allIosKoinModules объединяет:
+        //   - sqlDelightRouteModule (RouteDatabase, SearchResponseDatabase)
+        //   - sqlDelightSettingsModule (SettingsDatabase, SalarySettingDatabase)
+        //   - iosUseCaseModule (Repositories, UseCases, iOS ViewModels)
+        IosKoinHelperKt.doInitKoin(additionalModules: IosKoinModulesKt.allIosKoinModules)
     }
 
     var body: some Scene {

--- a/iosApp/src/iosMain/kotlin/com/z_company/iosapp/di/IosKoinModules.kt
+++ b/iosApp/src/iosMain/kotlin/com/z_company/iosapp/di/IosKoinModules.kt
@@ -1,0 +1,17 @@
+package com.z_company.iosapp.di
+
+import com.z_company.data_local.route.di.sqlDelightRouteModule
+import com.z_company.data_local.setting.di.sqlDelightSettingsModule
+import org.koin.core.module.Module
+
+/**
+ * Все Koin-модули, необходимые для инициализации iOS-приложения.
+ *
+ * Оборачивает модули из data_local, чтобы Swift не нуждался
+ * в прямом доступе к data_local (он не экспортирован из фреймворка).
+ */
+val allIosKoinModules: List<Module> = listOf(
+    sqlDelightRouteModule,       // DatabaseDriverFactory, RouteDatabase, SearchResponseDatabase
+    sqlDelightSettingsModule,    // SettingsDatabase, SalarySettingDatabase
+    iosUseCaseModule,            // Repositories, UseCases, iOS ViewModels
+)


### PR DESCRIPTION
data_local is not exported from ComposeApp framework, so Swift couldn't reference SqlDelightRouteModuleKt/SqlDelightSettingModuleKt directly. Created IosKoinModules.kt wrapper in iosApp/iosMain that re-exports all needed modules as allIosKoinModules property visible to Swift.