### PR TITLE
fix: update Compose MP 1.8.0→1.10.1 and Navigation 2.8.0-alpha10→2.9.2

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -129,9 +129,9 @@ object Versions {
     const val ktor_ver = "3.0.3"
     const val sqldelight_ver = "2.0.2"
     // Compose Multiplatform (совместим с Kotlin 2.2.0)
-    const val compose_mp_ver = "1.8.0"
-    // KMP Navigation-Compose (JetBrains fork androidx.navigation, совместим с Compose MP 1.8.0)
-    const val navigation_kmp_ver = "2.8.0-alpha10"
+    const val compose_mp_ver = "1.10.1"
+    // KMP Navigation-Compose (JetBrains fork androidx.navigation, совместим с Compose MP 1.10.x)
+    const val navigation_kmp_ver = "2.9.2"
 }
 
 object Libs {

--- a/iosApp/src/commonMain/kotlin/com/z_company/iosapp/navigation/AppNavHost.kt
+++ b/iosApp/src/commonMain/kotlin/com/z_company/iosapp/navigation/AppNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.savedstate.read
 import com.z_company.iosapp.screen.FormScreen
 import com.z_company.iosapp.screen.HomeScreen
 import com.z_company.iosapp.screen.ProfileScreen
@@ -38,7 +39,9 @@ fun AppNavHost() {
         }
         // FormRoute: "FormRoute?routeId={routeId}/?makeCopy={makeCopy}"
         composable(FormRoute.route) { backStackEntry ->
-            val routeId = backStackEntry.arguments?.getString("routeId")
+            val routeId = backStackEntry.arguments?.read {
+                if (contains("routeId")) getString("routeId") else null
+            }
             FormScreen(router = router, routeId = routeId)
         }
         composable(FormLoco.route) {

--- a/iosApp/src/commonMain/kotlin/com/z_company/iosapp/screen/FormScreen.kt
+++ b/iosApp/src/commonMain/kotlin/com/z_company/iosapp/screen/FormScreen.kt
@@ -171,6 +171,7 @@ internal fun FormScreen(
     }
 }
 
+@OptIn(kotlin.time.ExperimentalTime::class)
 private fun formatEpochMs(ms: Long): String {
     val instant = Instant.fromEpochMilliseconds(ms)
     val ldt = instant.toLocalDateTime(TimeZone.currentSystemDefault())


### PR DESCRIPTION
Fixes undefined symbol errors for stableprop_getter$artificial on iOS. Compose MP 1.8.0 was incompatible with Kotlin 2.2.0's Compose compiler. Also fixes:
- getString → SavedState.read {} for Navigation 2.9.x API
- Add @OptIn(ExperimentalTime) for Instant deprecation