### PR TITLE
fix: update kotlinx-datetime 0.6.2→0.7.1 for Kotlin 2.2.0 compat

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,6 +95,7 @@ android {
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.fromTarget(Apps.jvm_target_version)
+        freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -116,7 +116,7 @@ object Versions {
     const val mockito_core_ver = "3.10.0"
     const val mockito_inline_ver = "2.8.9"
     const val mockito_kotlin_ver = "1.5.0"
-    const val kotlinx_date_time_ver = "0.6.2"
+    const val kotlinx_date_time_ver = "0.7.1"
     const val ru_ok_tracer_platform_ver = "1.1.2"
     const val mytracker_sdk_ver = "3.3.2"
     const val retrofit_ver = "2.11.0"

--- a/core_android/build.gradle.kts
+++ b/core_android/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.fromTarget(Apps.jvm_target_version)
+        freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
     }
 }
 

--- a/core_android/src/main/java/com/z_company/core/ui/component/customDatePicker/DateUtil.kt
+++ b/core_android/src/main/java/com/z_company/core/ui/component/customDatePicker/DateUtil.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime

--- a/data_local/build.gradle.kts
+++ b/data_local/build.gradle.kts
@@ -23,6 +23,9 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.time.ExperimentalTime")
+        }
         commonMain.dependencies {
             api(project(Libs.project_domain))
             implementation(project(Libs.project_core))

--- a/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/BasicDataMapper.kt
+++ b/data_local/src/commonMain/kotlin/com/z_company/data_local/route/mapping/BasicDataMapper.kt
@@ -2,7 +2,7 @@ package com.z_company.data_local.route.mapping
 
 import com.zcompany.datalocal.route.db.BasicData as BasicDataRow
 import com.z_company.domain.entities.route.BasicData
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 internal object BasicDataMapper {
 

--- a/data_remote/build.gradle.kts
+++ b/data_remote/build.gradle.kts
@@ -22,6 +22,9 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.time.ExperimentalTime")
+        }
         commonMain.dependencies {
             api(project(Libs.project_domain))
             implementation(project(Libs.project_core))

--- a/data_remote/src/androidMain/kotlin/com/z_company/use_case/SubscriptionHelper.kt
+++ b/data_remote/src/androidMain/kotlin/com/z_company/use_case/SubscriptionHelper.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 //
 class SubscriptionHelper() : KoinComponent {
     private val settingsUseCase: SettingsUseCase by inject()

--- a/data_remote/src/androidMain/kotlin/com/z_company/work_manager/SyncWorker.kt
+++ b/data_remote/src/androidMain/kotlin/com/z_company/work_manager/SyncWorker.kt
@@ -18,7 +18,7 @@ import com.z_company.repository.remote_rest.SyncManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 

--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/SyncManager.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/SyncManager.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -24,6 +24,9 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.time.ExperimentalTime")
+        }
         commonMain.dependencies {
             api(project(Libs.project_core))
             implementation(Libs.kotlinx_coroutines_core)

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/MonthOfYear.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/MonthOfYear.kt
@@ -1,7 +1,7 @@
 package com.z_company.domain.entities
 
 import com.z_company.domain.util.generateId
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.Serializable

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/BasicData.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/BasicData.kt
@@ -2,7 +2,7 @@ package com.z_company.domain.entities.route
 
 import com.z_company.domain.entities.serializers.DateAsLongSerializer
 import com.z_company.domain.util.generateId
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/UtilsForEntities.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/route/UtilsForEntities.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/serializers/Serializers.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/serializers/Serializers.kt
@@ -1,6 +1,6 @@
 package com.z_company.domain.entities.serializers
 
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant

--- a/domain/src/commonMain/kotlin/com/z_company/domain/entities/setting/UserSettings.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/entities/setting/UserSettings.kt
@@ -3,7 +3,7 @@ package com.z_company.domain.entities.setting
 import com.z_company.domain.entities.MonthOfYear
 import com.z_company.domain.entities.route.LocoType
 import com.z_company.domain.util.generateId
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 
 const val SETTINGS_KEY = "User_Settings_Key"

--- a/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/use_cases/RouteUseCase.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime

--- a/features/route/build.gradle.kts
+++ b/features/route/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.fromTarget(Apps.jvm_target_version)
+        freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
     }
 }
 

--- a/iosApp/build.gradle.kts
+++ b/iosApp/build.gradle.kts
@@ -22,6 +22,9 @@ kotlin {
     }
 
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.time.ExperimentalTime")
+        }
         commonMain.dependencies {
             // Compose Multiplatform UI
             implementation(compose.runtime)


### PR DESCRIPTION
- Clock.System moved to kotlin.time.Clock.System — updated 11 imports
- Added ExperimentalTime opt-in to all modules using datetime
- Fixes runtime IrLinkageError: Clock.System not found on iOS