### PR TITLE
feat: Phase 1 — migrate 6 simple screens to :features:shared

### DIFF
--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/di/SharedModule.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/di/SharedModule.kt
@@ -2,7 +2,12 @@ package com.z_company.shared.di
 
 import com.z_company.shared.platform.PlatformActions
 import com.z_company.shared.platform.createPlatformActions
+import com.z_company.shared.viewmodel.MoreInfoSharedViewModel
+import com.z_company.shared.viewmodel.SalaryCalculationSharedViewModel
+import com.z_company.shared.viewmodel.SearchSharedViewModel
 import com.z_company.shared.viewmodel.SettingSalarySharedViewModel
+import com.z_company.shared.viewmodel.SettingsSharedViewModel
+import com.z_company.shared.viewmodel.WorkScheduleSharedViewModel
 import org.koin.dsl.module
 
 /**
@@ -15,4 +20,9 @@ val sharedModule = module {
 
     // Shared ViewModels
     factory { SettingSalarySharedViewModel(get()) }
+    factory { SearchSharedViewModel(get()) }
+    factory { WorkScheduleSharedViewModel(get(), get()) }
+    factory { SalaryCalculationSharedViewModel(get(), get()) }
+    factory { SettingsSharedViewModel(get()) }
+    factory { MoreInfoSharedViewModel(get(), get()) }
 }

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/MoreInfoScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/MoreInfoScreen.kt
@@ -1,0 +1,225 @@
+package com.z_company.shared.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.z_company.shared.util.TimeFormatter
+import com.z_company.shared.viewmodel.MoreInfoSharedViewModel
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoreInfoScreen(
+    monthId: String?,
+    onBackClick: () -> Unit,
+) {
+    val viewModel: MoreInfoSharedViewModel = koinInject()
+    val stats by viewModel.stats.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    LaunchedEffect(monthId) {
+        viewModel.loadForMonth(monthId)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Подробнее") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            stats == null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Нет данных",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            else -> {
+                val s = stats!!
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    item {
+                        Text(
+                            text = s.monthLabel,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+
+                    item {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            ),
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text(
+                                    text = "Статистика за месяц",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                )
+                                HorizontalDivider(
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.3f)
+                                )
+                                MoreInfoRow(
+                                    label = "Всего маршрутов",
+                                    value = s.routeCount.toString(),
+                                )
+                                MoreInfoRow(
+                                    label = "Общее рабочее время",
+                                    value = TimeFormatter.formatDuration(s.totalWorkMs),
+                                )
+                                MoreInfoRow(
+                                    label = "Общее время перерывов",
+                                    value = TimeFormatter.formatDuration(s.totalBreakMs),
+                                )
+                                MoreInfoRow(
+                                    label = "Среднее время маршрута",
+                                    value = TimeFormatter.formatDuration(s.averageWorkMs),
+                                )
+                            }
+                        }
+                    }
+
+                    if (s.routes.isNotEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = "Маршруты",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+
+                        items(s.routes, key = { it.routeId }) { routeInfo ->
+                            Card(
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                                ),
+                            ) {
+                                Column(
+                                    modifier = Modifier.padding(12.dp),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            text = routeInfo.number,
+                                            style = MaterialTheme.typography.titleSmall,
+                                            fontWeight = FontWeight.Medium,
+                                        )
+                                        routeInfo.startMs?.let {
+                                            Text(
+                                                text = TimeFormatter.formatDateTimeShort(it),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                    }
+                                    HorizontalDivider()
+                                    MoreInfoRow(
+                                        label = "Время работы",
+                                        value = TimeFormatter.formatDuration(routeInfo.workMs),
+                                    )
+                                    if (routeInfo.breakMs > 0) {
+                                        MoreInfoRow(
+                                            label = "Перерыв",
+                                            value = TimeFormatter.formatDuration(routeInfo.breakMs),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(8.dp)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoreInfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SalaryCalculationScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SalaryCalculationScreen.kt
@@ -1,0 +1,284 @@
+package com.z_company.shared.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.z_company.shared.util.TimeFormatter
+import com.z_company.shared.viewmodel.SalaryCalculationSharedViewModel
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SalaryCalculationScreen(
+    onBackClick: () -> Unit,
+    onShowSettingSalary: () -> Unit,
+) {
+    val viewModel: SalaryCalculationSharedViewModel = koinInject()
+    val summary by viewModel.summary.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Расчёт зарплаты") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
+        val s = summary
+        if (s == null) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Нет данных за выбранный месяц",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = s.month,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    StatMiniCard(
+                        title = "Маршрутов",
+                        value = s.routeCount.toString(),
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatMiniCard(
+                        title = "Рабочее время",
+                        value = TimeFormatter.formatDuration(s.totalWorkMs),
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    StatMiniCard(
+                        title = "Ночное время",
+                        value = TimeFormatter.formatDuration(s.totalNightMs),
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatMiniCard(
+                        title = "Перерывы",
+                        value = TimeFormatter.formatDuration(s.totalBreakMs),
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    ),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = "Сводка",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                        SummaryRow(label = "Маршрутов", value = s.routeCount.toString())
+                        SummaryRow(label = "Общее время работы", value = TimeFormatter.formatDurationHHMM(s.totalWorkMs))
+                        SummaryRow(label = "Ночное время", value = TimeFormatter.formatDurationHHMM(s.totalNightMs))
+                        SummaryRow(label = "Время перерывов", value = TimeFormatter.formatDurationHHMM(s.totalBreakMs))
+                    }
+                }
+            }
+
+            if (s.routes.isNotEmpty()) {
+                item {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "По маршрутам",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+
+                items(s.routes) { breakdown ->
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                        ),
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = breakdown.number,
+                                style = MaterialTheme.typography.titleSmall,
+                            )
+                            HorizontalDivider()
+                            RouteBreakdownRow(
+                                label = "Рабочее время",
+                                value = TimeFormatter.formatDuration(breakdown.workMs),
+                            )
+                            if (breakdown.breakMs > 0) {
+                                RouteBreakdownRow(
+                                    label = "Перерыв",
+                                    value = TimeFormatter.formatDuration(breakdown.breakMs),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = onShowSettingSalary,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Настройка зарплаты")
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatMiniCard(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SummaryRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun RouteBreakdownRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SearchScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SearchScreen.kt
@@ -1,0 +1,263 @@
+package com.z_company.shared.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.z_company.domain.entities.route.BasicData
+import com.z_company.domain.entities.route.Route
+import com.z_company.shared.util.TimeFormatter
+import com.z_company.shared.viewmodel.SearchSharedViewModel
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen(
+    onBackClick: () -> Unit,
+    onRouteClick: (BasicData) -> Unit,
+) {
+    val viewModel: SearchSharedViewModel = koinInject()
+    val query by viewModel.query.collectAsState()
+    val results by viewModel.results.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Поиск") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { viewModel.search(it) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                placeholder = { Text("Введите номер маршрута или заметки") },
+                leadingIcon = {
+                    Icon(Icons.Default.Search, contentDescription = null)
+                },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { viewModel.clearSearch() }) {
+                            Icon(Icons.Default.Clear, contentDescription = "Очистить")
+                        }
+                    }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Search,
+                ),
+                keyboardActions = KeyboardActions(
+                    onSearch = { /* search happens on input */ },
+                ),
+                shape = RoundedCornerShape(12.dp),
+            )
+
+            when {
+                query.isBlank() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = null,
+                                modifier = Modifier.size(48.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            )
+                            Text(
+                                text = "Введите номер маршрута или заметки",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+
+                results.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = null,
+                                modifier = Modifier.size(48.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            )
+                            Text(
+                                text = "Ничего не найдено",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text = "Попробуйте другой запрос",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            )
+                        }
+                    }
+                }
+
+                else -> {
+                    Text(
+                        text = "Найдено: ${results.size}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    )
+
+                    LazyColumn(
+                        contentPadding = PaddingValues(bottom = 16.dp),
+                    ) {
+                        items(results, key = { it.basicData.id }) { route ->
+                            SearchResultCard(
+                                route = route,
+                                onClick = { onRouteClick(route.basicData) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchResultCard(route: Route, onClick: () -> Unit) {
+    val basicData = route.basicData
+
+    val workDuration = run {
+        val start = basicData.timeStartWork ?: return@run null
+        val end = basicData.timeEndWork ?: return@run null
+        if (end > start) end - start else null
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        onClick = onClick,
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = basicData.number?.takeIf { it.isNotBlank() } ?: "Без номера",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.weight(1f),
+                )
+                workDuration?.let {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Text(
+                            text = TimeFormatter.formatDuration(it),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                        )
+                    }
+                }
+            }
+
+            basicData.timeStartWork?.let { start ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = TimeFormatter.formatDateTimeShort(start),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    basicData.timeEndWork?.let { end ->
+                        Text(
+                            text = "\u2192",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = TimeFormatter.formatDateTimeShort(end),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            basicData.notes?.takeIf { it.isNotBlank() }?.let { notes ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = notes,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SelectReleaseDaysScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SelectReleaseDaysScreen.kt
@@ -1,0 +1,240 @@
+package com.z_company.shared.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.z_company.shared.viewmodel.WorkScheduleSharedViewModel
+import kotlin.time.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+private val weekDayLabels = listOf("Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectReleaseDaysScreen(
+    onBackClick: () -> Unit,
+) {
+    val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+    var currentYear by remember { mutableStateOf(now.year) }
+    var currentMonth by remember { mutableStateOf<Int>(now.monthNumber) }
+    var selectedDays by remember { mutableStateOf(setOf<Int>()) }
+
+    val monthLabel = "${WorkScheduleSharedViewModel.monthNames.getOrElse(currentMonth - 1) { "?" }} $currentYear"
+    val daysInMonth = WorkScheduleSharedViewModel.getDaysInMonth(currentYear, currentMonth)
+    val firstDow = WorkScheduleSharedViewModel.getFirstDayOfWeekInMonth(currentYear, currentMonth)
+    val leadingEmpty = (firstDow - 1).coerceAtLeast(0)
+
+    val cells = buildList {
+        repeat(leadingEmpty) { add(0) }
+        for (d in 1..daysInMonth) add(d)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Дни отдыха") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "Выберите дни отдыха в календаре",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                IconButton(onClick = {
+                    if (currentMonth <= 1) {
+                        currentMonth = 12
+                        currentYear -= 1
+                    } else {
+                        currentMonth -= 1
+                    }
+                    selectedDays = emptySet()
+                }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Предыдущий месяц")
+                }
+                Text(
+                    text = monthLabel,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                IconButton(onClick = {
+                    if (currentMonth >= 12) {
+                        currentMonth = 1
+                        currentYear += 1
+                    } else {
+                        currentMonth += 1
+                    }
+                    selectedDays = emptySet()
+                }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "Следующий месяц")
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                weekDayLabels.forEach { label ->
+                    Text(
+                        text = label,
+                        modifier = Modifier.weight(1f),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(7),
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                items(cells) { day ->
+                    ReleaseDayCell(
+                        day = day,
+                        isSelected = day > 0 && selectedDays.contains(day),
+                        onToggle = {
+                            if (day > 0) {
+                                selectedDays = if (selectedDays.contains(day)) {
+                                    selectedDays - day
+                                } else {
+                                    selectedDays + day
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (selectedDays.isNotEmpty()) {
+                Text(
+                    text = "Выбрано дней: ${selectedDays.size}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Дни: ${selectedDays.sorted().joinToString(", ")}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                Text(
+                    text = "Дни отдыха не выбраны",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReleaseDayCell(
+    day: Int,
+    isSelected: Boolean,
+    onToggle: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(4.dp))
+            .then(
+                if (isSelected)
+                    Modifier.background(MaterialTheme.colorScheme.tertiaryContainer)
+                else
+                    Modifier
+            )
+            .then(
+                if (day > 0)
+                    Modifier.border(
+                        width = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                else
+                    Modifier
+            )
+            .then(if (day > 0) Modifier.clickable(onClick = onToggle) else Modifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (day > 0) {
+            Text(
+                text = day.toString(),
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 11.sp,
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                color = if (isSelected)
+                    MaterialTheme.colorScheme.onTertiaryContainer
+                else
+                    MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SettingsScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SettingsScreen.kt
@@ -1,0 +1,235 @@
+package com.z_company.shared.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.z_company.shared.util.TimeFormatter
+import com.z_company.shared.viewmodel.SettingsSharedViewModel
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    onBackClick: () -> Unit,
+    onShowSettingSalary: () -> Unit,
+) {
+    val viewModel: SettingsSharedViewModel = koinInject()
+    val settings by viewModel.settings.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Настройки") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
+        val s = settings
+        if (s == null) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Настройки не найдены",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Scaffold
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Spacer(modifier = Modifier.height(4.dp))
+
+            SettingsSectionCard(title = "Общие") {
+                SettingsToggleRow(
+                    label = "Учитывать будущие маршруты",
+                    checked = s.isConsiderFutureRoute,
+                    onCheckedChange = { viewModel.setConsiderFutureRoute(it) },
+                )
+                SettingsToggleRow(
+                    label = "Показывать перерыв",
+                    checked = s.isShowBreak,
+                    onCheckedChange = { viewModel.setShowBreak(it) },
+                )
+                SettingsValueRow(
+                    label = "Десятичное время",
+                    value = if (s.isDecimalTime) "Да" else "Нет",
+                )
+            }
+
+            SettingsSectionCard(title = "Время") {
+                SettingsValueRow(
+                    label = "Ночное время",
+                    value = s.nightTime.toString(),
+                )
+                SettingsValueRow(
+                    label = "Временная зона",
+                    value = TimeFormatter.formatTimeZone(s.timeZone),
+                )
+                SettingsValueRow(
+                    label = "Минимальный отдых в ПО",
+                    value = TimeFormatter.formatHoursFromMs(s.minTimeRestPointOfTurnover),
+                )
+                SettingsValueRow(
+                    label = "Минимальный домашний отдых",
+                    value = TimeFormatter.formatHoursFromMs(s.minTimeHomeRest),
+                )
+                if (s.usingDefaultWorkTime) {
+                    SettingsValueRow(
+                        label = "Время работы по умолчанию",
+                        value = TimeFormatter.formatHoursFromMs(s.defaultWorkTime),
+                    )
+                }
+            }
+
+            SettingsSectionCard(title = "Локомотив") {
+                SettingsValueRow(
+                    label = "Тип по умолчанию",
+                    value = s.defaultLocoType.text,
+                )
+                SettingsValueRow(
+                    label = "Коэффициент дизтоплива",
+                    value = s.lastEnteredDieselCoefficient.toString(),
+                )
+                if (s.locomotiveSeriesList.isNotEmpty()) {
+                    SettingsValueRow(
+                        label = "Серии локомотивов",
+                        value = s.locomotiveSeriesList.joinToString(", "),
+                    )
+                }
+                if (s.stationList.isNotEmpty()) {
+                    SettingsValueRow(
+                        label = "Станции",
+                        value = s.stationList.joinToString(", "),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Button(
+                onClick = onShowSettingSalary,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Настройка зарплаты")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun SettingsSectionCard(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun SettingsValueRow(label: String, value: String) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun SettingsToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f).padding(end = 8.dp),
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/WorkScheduleScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/WorkScheduleScreen.kt
@@ -1,0 +1,251 @@
+package com.z_company.shared.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.z_company.shared.util.TimeFormatter
+import com.z_company.shared.viewmodel.DayCell
+import com.z_company.shared.viewmodel.WorkScheduleSharedViewModel
+import org.koin.compose.koinInject
+
+private val dayOfWeekLabels = listOf("Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkScheduleScreen(
+    onBackClick: () -> Unit,
+) {
+    val viewModel: WorkScheduleSharedViewModel = koinInject()
+    val settings by viewModel.settings.collectAsState()
+    val dayCells by viewModel.dayCells.collectAsState()
+    val totalRouteCount by viewModel.totalRouteCount.collectAsState()
+    val totalWorkMs by viewModel.totalWorkMs.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    val monthLabel = settings?.selectMonthOfYear?.let { moy ->
+        "${WorkScheduleSharedViewModel.monthNames.getOrElse(moy.month) { "?" }} ${moy.year}"
+    } ?: "Загрузка..."
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("График работы") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                IconButton(onClick = { viewModel.setPreviousMonth() }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Предыдущий месяц")
+                }
+                Text(
+                    text = monthLabel,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                IconButton(onClick = { viewModel.setNextMonth() }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "Следующий месяц")
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                dayOfWeekLabels.forEach { label ->
+                    Text(
+                        text = label,
+                        modifier = Modifier.weight(1f),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            if (isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(200.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(7),
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    items(dayCells) { cell ->
+                        CalendarDayCell(cell = cell)
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                ),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = "Итого за месяц",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            text = "Маршрутов",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = "$totalRouteCount",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            text = "Общее рабочее время",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = TimeFormatter.formatDuration(totalWorkMs),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CalendarDayCell(cell: DayCell) {
+    Box(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(4.dp))
+            .then(
+                if (cell.hasRoute)
+                    Modifier.background(MaterialTheme.colorScheme.primaryContainer)
+                else
+                    Modifier
+            )
+            .then(
+                if (cell.dayOfMonth > 0)
+                    Modifier.border(
+                        width = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                else
+                    Modifier
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (cell.dayOfMonth > 0) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = cell.dayOfMonth.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontSize = 11.sp,
+                    fontWeight = if (cell.hasRoute) FontWeight.Bold else FontWeight.Normal,
+                    color = if (cell.hasRoute)
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    else
+                        MaterialTheme.colorScheme.onSurface,
+                )
+                if (cell.hasRoute) {
+                    Box(
+                        modifier = Modifier
+                            .size(4.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primary),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/util/TimeFormatter.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/util/TimeFormatter.kt
@@ -1,0 +1,71 @@
+package com.z_company.shared.util
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Shared time formatting utilities for both Android and iOS.
+ */
+object TimeFormatter {
+    val monthNames = listOf(
+        "Январь", "Февраль", "Март", "Апрель", "Май", "Июнь",
+        "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"
+    )
+
+    /** Format epoch millis to "dd.MM.yyyy HH:mm" */
+    fun formatDateTime(millis: Long): String {
+        val instant = Instant.fromEpochMilliseconds(millis)
+        val ldt = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+        val d = ldt.dayOfMonth.toString().padStart(2, '0')
+        val mo = ldt.monthNumber.toString().padStart(2, '0')
+        val h = ldt.hour.toString().padStart(2, '0')
+        val min = ldt.minute.toString().padStart(2, '0')
+        return "$d.$mo.${ldt.year} $h:$min"
+    }
+
+    /** Format epoch millis to "dd.MM HH:mm" (short) */
+    fun formatDateTimeShort(millis: Long): String {
+        val instant = Instant.fromEpochMilliseconds(millis)
+        val ldt = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+        val d = ldt.dayOfMonth.toString().padStart(2, '0')
+        val mo = ldt.monthNumber.toString().padStart(2, '0')
+        val h = ldt.hour.toString().padStart(2, '0')
+        val min = ldt.minute.toString().padStart(2, '0')
+        return "$d.$mo $h:$min"
+    }
+
+    /** Format duration millis to "Xч Yмин" */
+    fun formatDuration(millis: Long): String {
+        if (millis <= 0) return "—"
+        val hours = millis / 3_600_000
+        val minutes = (millis % 3_600_000) / 60_000
+        return if (hours > 0) "${hours}ч ${minutes}мин" else "${minutes}мин"
+    }
+
+    /** Format duration millis to "HH:MM" */
+    fun formatDurationHHMM(millis: Long): String {
+        if (millis <= 0) return "00:00"
+        val hours = millis / 3_600_000
+        val minutes = (millis % 3_600_000) / 60_000
+        return "${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}"
+    }
+
+    /** Formats milliseconds as "X ч" or "X ч Y мин" */
+    fun formatHoursFromMs(ms: Long): String {
+        val hours = ms / 3_600_000L
+        val minutes = (ms % 3_600_000L) / 60_000L
+        return if (minutes > 0) "$hours ч $minutes мин" else "$hours ч"
+    }
+
+    /** Formats timezone offset to readable string */
+    fun formatTimeZone(timeZoneMs: Long): String {
+        val totalHoursFromMoscow = timeZoneMs / 3_600_000L
+        val moscowOffset = 3L + totalHoursFromMoscow
+        return if (totalHoursFromMoscow == 0L) {
+            "МСК (UTC+3)"
+        } else {
+            "UTC+$moscowOffset (МСК${if (totalHoursFromMoscow > 0) "+" else ""}$totalHoursFromMoscow)"
+        }
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/MoreInfoSharedViewModel.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/MoreInfoSharedViewModel.kt
@@ -1,0 +1,100 @@
+package com.z_company.shared.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.z_company.domain.entities.MonthOfYear
+import com.z_company.domain.entities.route.UtilsForEntities.getBreakDuration
+import com.z_company.domain.entities.route.UtilsForEntities.getWorkTime
+import com.z_company.domain.entities.setting.UserSettings
+import com.z_company.domain.use_cases.RouteUseCase
+import com.z_company.domain.use_cases.SettingsUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Shared ViewModel for the "more info" monthly statistics screen.
+ */
+class MoreInfoSharedViewModel(
+    private val routeUseCase: RouteUseCase,
+    private val settingsUseCase: SettingsUseCase,
+) : ViewModel() {
+
+    data class RouteInfo(
+        val routeId: String,
+        val number: String,
+        val startMs: Long?,
+        val workMs: Long,
+        val breakMs: Long,
+    )
+
+    data class MonthStats(
+        val monthLabel: String,
+        val routeCount: Int,
+        val totalWorkMs: Long,
+        val totalBreakMs: Long,
+        val averageWorkMs: Long,
+        val routes: List<RouteInfo>,
+    )
+
+    private val _stats = MutableStateFlow<MonthStats?>(null)
+    val stats: StateFlow<MonthStats?> = _stats.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    fun loadForMonth(monthId: String?) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            settingsUseCase.getUserSettingFlow().collect { settings ->
+                val targetMonth = resolveMonth(settings, monthId)
+                loadRoutesForMonth(settings, targetMonth)
+            }
+        }
+    }
+
+    private fun resolveMonth(settings: UserSettings, monthId: String?): MonthOfYear {
+        if (monthId == null) return settings.selectMonthOfYear
+        val selected = settings.selectMonthOfYear
+        return if (selected.id == monthId) selected else settings.selectMonthOfYear
+    }
+
+    private suspend fun loadRoutesForMonth(settings: UserSettings, month: MonthOfYear) {
+        routeUseCase.routeListByMonthFlow(
+            monthOfYear = month,
+            offsetInMoscow = settings.timeZone,
+        ).collect { routes ->
+            val routeInfos = routes.map { route ->
+                RouteInfo(
+                    routeId = route.basicData.id,
+                    number = route.basicData.number?.takeIf { it.isNotBlank() } ?: "Без номера",
+                    startMs = route.basicData.timeStartWork,
+                    workMs = route.getWorkTime() ?: 0L,
+                    breakMs = route.getBreakDuration(),
+                )
+            }
+            val totalWork = routeInfos.sumOf { it.workMs }
+            val totalBreak = routeInfos.sumOf { it.breakMs }
+            val avg = if (routeInfos.isNotEmpty()) totalWork / routeInfos.size else 0L
+
+            _stats.value = MonthStats(
+                monthLabel = formatMonth(month),
+                routeCount = routes.size,
+                totalWorkMs = totalWork,
+                totalBreakMs = totalBreak,
+                averageWorkMs = avg,
+                routes = routeInfos.sortedByDescending { it.startMs ?: 0L },
+            )
+            _isLoading.value = false
+        }
+    }
+
+    private fun formatMonth(moy: MonthOfYear): String {
+        val names = listOf(
+            "Январь", "Февраль", "Март", "Апрель", "Май", "Июнь",
+            "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь",
+        )
+        return "${names.getOrElse(moy.month) { "?" }} ${moy.year}"
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/SalaryCalculationSharedViewModel.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/SalaryCalculationSharedViewModel.kt
@@ -1,0 +1,110 @@
+package com.z_company.shared.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.z_company.domain.entities.route.UtilsForEntities.getBreakDuration
+import com.z_company.domain.entities.route.UtilsForEntities.getNightTime
+import com.z_company.domain.entities.route.UtilsForEntities.getWorkTime
+import com.z_company.domain.entities.setting.UserSettings
+import com.z_company.domain.use_cases.RouteUseCase
+import com.z_company.domain.use_cases.SettingsUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Shared ViewModel for the salary calculation screen.
+ */
+class SalaryCalculationSharedViewModel(
+    private val routeUseCase: RouteUseCase,
+    private val settingsUseCase: SettingsUseCase,
+) : ViewModel() {
+
+    data class RouteBreakdown(
+        val routeId: String,
+        val number: String,
+        val workMs: Long,
+        val breakMs: Long,
+    )
+
+    data class MonthlySummary(
+        val month: String,
+        val routeCount: Int,
+        val totalWorkMs: Long,
+        val totalBreakMs: Long,
+        val totalNightMs: Long,
+        val routes: List<RouteBreakdown>,
+    ) {
+        val totalWorkHours: Long get() = totalWorkMs / (1000L * 60 * 60)
+        val totalWorkMinutes: Long get() = (totalWorkMs / (1000L * 60)) % 60
+    }
+
+    private val _summary = MutableStateFlow<MonthlySummary?>(null)
+    val summary: StateFlow<MonthlySummary?> = _summary.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private var routesJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            settingsUseCase.getUserSettingFlow().collect { settings ->
+                loadSummary(settings)
+            }
+        }
+    }
+
+    private fun loadSummary(settings: UserSettings) {
+        routesJob?.cancel()
+        routesJob = viewModelScope.launch {
+            _isLoading.value = true
+            routeUseCase.routeListByMonthFlow(
+                monthOfYear = settings.selectMonthOfYear,
+                offsetInMoscow = settings.timeZone,
+            ).collect { routes ->
+                val breakdowns = routes.map { route ->
+                    val workMs = route.getWorkTime() ?: 0L
+                    val breakMs = route.getBreakDuration()
+                    RouteBreakdown(
+                        routeId = route.basicData.id,
+                        number = route.basicData.number?.takeIf { it.isNotBlank() } ?: "Без номера",
+                        workMs = workMs,
+                        breakMs = breakMs,
+                    )
+                }
+
+                val totalWorkMs = breakdowns.sumOf { it.workMs }
+                val totalBreakMs = breakdowns.sumOf { it.breakMs }
+
+                val totalNightMs = try {
+                    routes.getNightTime(settings)
+                } catch (_: Exception) {
+                    0L
+                }
+
+                _summary.value = MonthlySummary(
+                    month = formatMonth(settings),
+                    routeCount = routes.size,
+                    totalWorkMs = totalWorkMs,
+                    totalBreakMs = totalBreakMs,
+                    totalNightMs = totalNightMs,
+                    routes = breakdowns,
+                )
+                _isLoading.value = false
+            }
+        }
+    }
+
+    private fun formatMonth(settings: UserSettings): String {
+        val monthNames = listOf(
+            "Январь", "Февраль", "Март", "Апрель", "Май", "Июнь",
+            "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь",
+        )
+        val moy = settings.selectMonthOfYear
+        val name = monthNames.getOrElse(moy.month) { "?" }
+        return "$name ${moy.year}"
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/SearchSharedViewModel.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/SearchSharedViewModel.kt
@@ -1,0 +1,90 @@
+package com.z_company.shared.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.z_company.domain.entities.route.Route
+import com.z_company.domain.use_cases.RouteUseCase
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+/**
+ * Shared ViewModel for the search screen.
+ *
+ * Loads all routes from repository, then filters them locally by
+ * route number or notes when the query changes.
+ */
+@OptIn(FlowPreview::class)
+class SearchSharedViewModel(
+    private val routeUseCase: RouteUseCase,
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    private val _results = MutableStateFlow<List<Route>>(emptyList())
+    val results: StateFlow<List<Route>> = _results.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _allRoutes = MutableStateFlow<List<Route>>(emptyList())
+
+    private var loadJob: Job? = null
+    private var searchJob: Job? = null
+
+    init {
+        loadAllRoutes()
+        observeQueryChanges()
+    }
+
+    private fun loadAllRoutes() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            routeUseCase.getListRoutesAsFlow().collect { routes ->
+                _allRoutes.value = routes.sortedByDescending { it.basicData.timeStartWork ?: 0L }
+                applyFilter(_query.value)
+            }
+        }
+    }
+
+    private fun observeQueryChanges() {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            _query
+                .debounce(200)
+                .distinctUntilChanged()
+                .collect { q -> applyFilter(q) }
+        }
+    }
+
+    private fun applyFilter(q: String) {
+        val trimmed = q.trim()
+        _isLoading.value = true
+        _results.value = if (trimmed.isBlank()) {
+            emptyList()
+        } else {
+            val lower = trimmed.lowercase()
+            _allRoutes.value.filter { route ->
+                val number = route.basicData.number?.lowercase() ?: ""
+                val notes = route.basicData.notes?.lowercase() ?: ""
+                number.contains(lower) || notes.contains(lower)
+            }
+        }
+        _isLoading.value = false
+    }
+
+    fun search(query: String) {
+        _query.value = query
+    }
+
+    fun clearSearch() {
+        _query.value = ""
+        _results.value = emptyList()
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/SettingsSharedViewModel.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/SettingsSharedViewModel.kt
@@ -1,0 +1,56 @@
+package com.z_company.shared.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.z_company.core.ResultState
+import com.z_company.domain.entities.setting.UserSettings
+import com.z_company.domain.use_cases.SettingsUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Shared ViewModel for the settings screen.
+ */
+class SettingsSharedViewModel(
+    private val settingsUseCase: SettingsUseCase,
+) : ViewModel() {
+
+    private val _settings = MutableStateFlow<UserSettings?>(null)
+    val settings: StateFlow<UserSettings?> = _settings.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            settingsUseCase.getUserSettingFlow().collect { userSettings ->
+                _settings.value = userSettings
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun setConsiderFutureRoute(value: Boolean) {
+        val current = _settings.value ?: return
+        val updated = current.copy(isConsiderFutureRoute = value)
+        viewModelScope.launch {
+            settingsUseCase.saveSetting(updated).collect { result ->
+                if (result is ResultState.Success) {
+                    _settings.value = updated
+                }
+            }
+        }
+    }
+
+    fun setShowBreak(value: Boolean) {
+        viewModelScope.launch {
+            settingsUseCase.setShowBreak(value).collect { result ->
+                if (result is ResultState.Success) {
+                    _settings.value = _settings.value?.copy(isShowBreak = value)
+                }
+            }
+        }
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/WorkScheduleSharedViewModel.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/viewmodel/WorkScheduleSharedViewModel.kt
@@ -1,0 +1,162 @@
+package com.z_company.shared.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.z_company.domain.entities.MonthOfYear
+import com.z_company.domain.entities.route.Route
+import com.z_company.domain.entities.route.UtilsForEntities.getWorkTime
+import com.z_company.domain.entities.setting.UserSettings
+import com.z_company.domain.use_cases.RouteUseCase
+import com.z_company.domain.use_cases.SettingsUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Day cell data for the calendar grid.
+ */
+data class DayCell(
+    val dayOfMonth: Int,
+    val hasRoute: Boolean,
+    val routeCount: Int,
+)
+
+/**
+ * Shared ViewModel for the work schedule calendar screen.
+ */
+class WorkScheduleSharedViewModel(
+    private val routeUseCase: RouteUseCase,
+    private val settingsUseCase: SettingsUseCase,
+) : ViewModel() {
+
+    private val _settings = MutableStateFlow<UserSettings?>(null)
+    val settings: StateFlow<UserSettings?> = _settings.asStateFlow()
+
+    private val _routes = MutableStateFlow<List<Route>>(emptyList())
+    val routes: StateFlow<List<Route>> = _routes.asStateFlow()
+
+    private val _dayCells = MutableStateFlow<List<DayCell>>(emptyList())
+    val dayCells: StateFlow<List<DayCell>> = _dayCells.asStateFlow()
+
+    private val _totalRouteCount = MutableStateFlow(0)
+    val totalRouteCount: StateFlow<Int> = _totalRouteCount.asStateFlow()
+
+    private val _totalWorkMs = MutableStateFlow(0L)
+    val totalWorkMs: StateFlow<Long> = _totalWorkMs.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private var routesJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            settingsUseCase.getUserSettingFlow().collect { userSettings ->
+                _settings.value = userSettings
+                loadRoutesForMonth(userSettings)
+            }
+        }
+    }
+
+    private fun loadRoutesForMonth(userSettings: UserSettings) {
+        routesJob?.cancel()
+        routesJob = viewModelScope.launch {
+            _isLoading.value = true
+            routeUseCase.routeListByMonthFlow(
+                monthOfYear = userSettings.selectMonthOfYear,
+                offsetInMoscow = userSettings.timeZone,
+            ).collect { routes ->
+                _routes.value = routes
+                buildCalendarGrid(routes, userSettings.selectMonthOfYear)
+                _totalRouteCount.value = routes.size
+                _totalWorkMs.value = routes.sumOf { it.getWorkTime() ?: 0L }
+                _isLoading.value = false
+            }
+        }
+    }
+
+    private fun buildCalendarGrid(routes: List<Route>, moy: MonthOfYear) {
+        val year = moy.year
+        val month = moy.month + 1
+
+        val daysInMonth = getDaysInMonth(year, month)
+        val firstDayOfWeek = getFirstDayOfWeekInMonth(year, month)
+        val leadingEmpty = (firstDayOfWeek - 1).coerceAtLeast(0)
+
+        val routesByDay = mutableMapOf<Int, Int>()
+        val tz = TimeZone.currentSystemDefault()
+        routes.forEach { route ->
+            val startMs = route.basicData.timeStartWork ?: return@forEach
+            val ldt = Instant.fromEpochMilliseconds(startMs).toLocalDateTime(tz)
+            if (ldt.year == year && ldt.monthNumber == month) {
+                val day = ldt.dayOfMonth
+                routesByDay[day] = (routesByDay[day] ?: 0) + 1
+            }
+        }
+
+        val cells = mutableListOf<DayCell>()
+        repeat(leadingEmpty) { cells.add(DayCell(dayOfMonth = 0, hasRoute = false, routeCount = 0)) }
+        for (day in 1..daysInMonth) {
+            val count = routesByDay[day] ?: 0
+            cells.add(DayCell(dayOfMonth = day, hasRoute = count > 0, routeCount = count))
+        }
+        _dayCells.value = cells
+    }
+
+    fun setNextMonth() {
+        val current = _settings.value ?: return
+        val moy = current.selectMonthOfYear
+        val newMonth = if (moy.month >= 11) 0 else moy.month + 1
+        val newYear = if (moy.month >= 11) moy.year + 1 else moy.year
+        updateMonth(newYear, newMonth)
+    }
+
+    fun setPreviousMonth() {
+        val current = _settings.value ?: return
+        val moy = current.selectMonthOfYear
+        val newMonth = if (moy.month <= 0) 11 else moy.month - 1
+        val newYear = if (moy.month <= 0) moy.year - 1 else moy.year
+        updateMonth(newYear, newMonth)
+    }
+
+    private fun updateMonth(year: Int, month: Int) {
+        viewModelScope.launch {
+            settingsUseCase.updateMonthOfYearInUserSetting(
+                MonthOfYear(year = year, month = month)
+            ).collect { /* result */ }
+        }
+    }
+
+    companion object {
+        val monthNames = listOf(
+            "Январь", "Февраль", "Март", "Апрель", "Май", "Июнь",
+            "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь",
+        )
+
+        fun getDaysInMonth(year: Int, month: Int): Int {
+            return when (month) {
+                1, 3, 5, 7, 8, 10, 12 -> 31
+                4, 6, 9, 11 -> 30
+                2 -> if (isLeapYear(year)) 29 else 28
+                else -> 30
+            }
+        }
+
+        private fun isLeapYear(year: Int): Boolean =
+            (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+
+        fun getFirstDayOfWeekInMonth(year: Int, month: Int): Int {
+            val y = if (month < 3) year - 1 else year
+            val m = if (month < 3) month + 12 else month
+            val k = y % 100
+            val j = y / 100
+            val h = (1 + (13 * (m + 1)) / 5 + k + k / 4 + j / 4 - 2 * j) % 7
+            return ((h + 5) % 7) + 1
+        }
+    }
+}

--- a/iosApp/build.gradle.kts
+++ b/iosApp/build.gradle.kts
@@ -42,6 +42,9 @@ kotlin {
             implementation(project(Libs.project_domain))
             implementation(project(Libs.project_core))
 
+            // Shared UI screens and ViewModels
+            implementation(project(Libs.project_feature_shared))
+
             // DI + утилиты
             implementation(Libs.koin_core)
             implementation(Libs.koin_compose)   // koinInject() для Compose MP

--- a/iosApp/src/commonMain/kotlin/com/z_company/iosapp/navigation/AppNavHost.kt
+++ b/iosApp/src/commonMain/kotlin/com/z_company/iosapp/navigation/AppNavHost.kt
@@ -13,15 +13,17 @@ import com.z_company.iosapp.screen.FormPassengerScreen
 import com.z_company.iosapp.screen.FormScreen
 import com.z_company.iosapp.screen.FormTrainScreen
 import com.z_company.iosapp.screen.HomeScreen
-import com.z_company.iosapp.screen.MoreInfoScreen
 import com.z_company.iosapp.screen.ProfileScreen
-import com.z_company.iosapp.screen.SalaryCalculationScreen
-import com.z_company.iosapp.screen.SearchScreen
-import com.z_company.iosapp.screen.SelectReleaseDaysScreen
 import com.z_company.iosapp.screen.SettingSalaryScreen
-import com.z_company.iosapp.screen.SettingsScreen
 import com.z_company.iosapp.screen.PurchasesScreen
-import com.z_company.iosapp.screen.WorkScheduleScreen
+
+// Shared screens from :features:shared
+import com.z_company.shared.ui.screen.MoreInfoScreen as SharedMoreInfoScreen
+import com.z_company.shared.ui.screen.SalaryCalculationScreen as SharedSalaryCalculationScreen
+import com.z_company.shared.ui.screen.SearchScreen as SharedSearchScreen
+import com.z_company.shared.ui.screen.SelectReleaseDaysScreen as SharedSelectReleaseDaysScreen
+import com.z_company.shared.ui.screen.SettingsScreen as SharedSettingsScreen
+import com.z_company.shared.ui.screen.WorkScheduleScreen as SharedWorkScheduleScreen
 
 /**
  * Корневой NavHost iOS-приложения.
@@ -29,6 +31,8 @@ import com.z_company.iosapp.screen.WorkScheduleScreen
  * Маршруты совпадают со строками в features/route/navigation/Routes.kt,
  * чтобы при миграции features на Compose Multiplatform стабы заменялись
  * реальными экранами без изменения навигационного графа.
+ *
+ * Экраны, мигрированные в :features:shared, теперь используются напрямую.
  */
 @Composable
 fun AppNavHost() {
@@ -46,7 +50,6 @@ fun AppNavHost() {
         composable(HomeRoute.route) {
             HomeScreen(router = router)
         }
-        // FormRoute: "FormRoute?routeId={routeId}/?makeCopy={makeCopy}"
         composable(FormRoute.route) { backStackEntry ->
             val routeId = backStackEntry.arguments?.read {
                 if (contains("routeId")) getString("routeId") else null
@@ -80,20 +83,31 @@ fun AppNavHost() {
             }
             FormPassengerScreen(router = router, basicId = basicId, passengerId = passengerId)
         }
+
+        // --- Shared screens from :features:shared ---
         composable(SettingsScreenRoute.route) {
-            SettingsScreen(router = router)
+            SharedSettingsScreen(
+                onBackClick = { router.back() },
+                onShowSettingSalary = { router.showSettingSalary() },
+            )
         }
         composable(ProfileRoute.route) {
             ProfileScreen(router = router)
         }
         composable(SalaryCalculationRoute.route) {
-            SalaryCalculationScreen(router = router)
+            SharedSalaryCalculationScreen(
+                onBackClick = { router.back() },
+                onShowSettingSalary = { router.showSettingSalary() },
+            )
         }
         composable(SettingSalaryRoute.route) {
             SettingSalaryScreen(router = router)
         }
         composable(SearchRoute.route) {
-            SearchScreen(router = router)
+            SharedSearchScreen(
+                onBackClick = { router.back() },
+                onRouteClick = { basicData -> router.showRouteDetails(basicData) },
+            )
         }
         composable(PurchasesRoute.route) {
             PurchasesScreen(router = router)
@@ -102,16 +116,23 @@ fun AppNavHost() {
             AllRouteScreen(router = router)
         }
         composable(WorkScheduleScreenRoute.route) {
-            WorkScheduleScreen(router = router)
+            SharedWorkScheduleScreen(
+                onBackClick = { router.back() },
+            )
         }
         composable(SelectReleaseDaysScreenRoute.route) {
-            SelectReleaseDaysScreen(router = router)
+            SharedSelectReleaseDaysScreen(
+                onBackClick = { router.back() },
+            )
         }
         composable(MoreInfoRoute.route) { backStackEntry ->
             val monthId = backStackEntry.arguments?.read {
                 if (contains("monthId")) getString("monthId") else null
             }
-            MoreInfoScreen(router = router, monthId = monthId)
+            SharedMoreInfoScreen(
+                monthId = monthId,
+                onBackClick = { router.back() },
+            )
         }
     }
 }

--- a/iosApp/src/iosMain/kotlin/com/z_company/iosapp/di/IosKoinModules.kt
+++ b/iosApp/src/iosMain/kotlin/com/z_company/iosapp/di/IosKoinModules.kt
@@ -2,6 +2,7 @@ package com.z_company.iosapp.di
 
 import com.z_company.data_local.route.di.sqlDelightRouteModule
 import com.z_company.data_local.setting.di.sqlDelightSettingsModule
+import com.z_company.shared.di.sharedModule
 import org.koin.core.module.Module
 
 /**
@@ -14,4 +15,5 @@ val allIosKoinModules: List<Module> = listOf(
     sqlDelightRouteModule,       // DatabaseDriverFactory, RouteDatabase, SearchResponseDatabase
     sqlDelightSettingsModule,    // SettingsDatabase, SalarySettingDatabase
     iosUseCaseModule,            // Repositories, UseCases, iOS ViewModels
+    sharedModule,                // Shared ViewModels (SearchShared, WorkScheduleShared, etc.)
 )


### PR DESCRIPTION
Migrate SearchScreen, SelectReleaseDaysScreen, WorkScheduleScreen, SalaryCalculationScreen, SettingsScreen, MoreInfoScreen from iosApp to shared module with corresponding ViewModels. iOS AppNavHost now uses shared screens with callback lambdas instead of Router interface.

New files:
- shared/util/TimeFormatter.kt — cross-platform date/time formatting
- shared/viewmodel/{Search,WorkSchedule,SalaryCalculation,Settings,MoreInfo}SharedViewModel.kt
- shared/ui/screen/{Search,SelectReleaseDays,WorkSchedule,SalaryCalculation,Settings,MoreInfo}Screen.kt

Updated:
- SharedModule.kt — register all new ViewModels in Koin
- iosApp/build.gradle.kts — add :features:shared dependency
- AppNavHost.kt — use shared screens for 6 migrated routes
- IosKoinModules.kt — include sharedModule in iOS Koin config

Build verified: Android assembleDebug ✅, iOS linkDebugFramework ✅