### PR TITLE
fix: resolve iOS Compose Multiplatform crash with unbounded Constraints

### DIFF
--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/AllRouteScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/AllRouteScreen.kt
@@ -271,14 +271,14 @@ fun AllRouteScreen(
             when {
                 isLoading -> {
                     Box(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxWidth().weight(1f),
                         contentAlignment = Alignment.Center,
                     ) { CircularProgressIndicator() }
                 }
 
                 routes.isEmpty() -> {
                     Box(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxWidth().weight(1f),
                         contentAlignment = Alignment.Center,
                     ) {
                         Column(
@@ -309,7 +309,7 @@ fun AllRouteScreen(
                     )
 
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxWidth().weight(1f),
                         contentPadding = PaddingValues(8.dp),
                     ) {
                         items(routes, key = { it.basicData.id }) { route ->

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SearchScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SearchScreen.kt
@@ -149,116 +149,120 @@ fun SearchScreen(
                 }
             }
 
-            // Search results
-            when (val state = uiState.searchState) {
-                is SearchStateScreen.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) { CircularProgressIndicator() }
-                }
+            // Content area — Box with weight(1f) gives bounded height,
+            // preventing iOS Compose Multiplatform crash with Int.MAX_VALUE constraints.
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                // Search results
+                when (val state = uiState.searchState) {
+                    is SearchStateScreen.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center,
+                        ) { CircularProgressIndicator() }
+                    }
 
-                is SearchStateScreen.Success -> {
-                    val results = state.data
-                    if (results != null && uiState.isVisibleResult) {
-                        if (results.isEmpty()) {
-                            Box(
-                                modifier = Modifier.fillMaxWidth().padding(24.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Text(
-                                    text = "Ничего не найдено",
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        } else {
-                            LazyColumn(
-                                modifier = Modifier.padding(top = 12.dp),
-                                verticalArrangement = Arrangement.Top,
-                                state = scrollState,
-                            ) {
-                                items(results, key = { it.route.basicData.id }) { routeWithTag ->
-                                    SearchListItem(
-                                        route = routeWithTag.route,
-                                        searchTag = routeWithTag.tag,
-                                        searchValue = queryText,
-                                        entityString = viewModel.entityString,
-                                        onClick = { onRouteClick(routeWithTag.route.basicData) },
-                                    )
-                                }
-                            }
-                        }
-                    } else if (queryText.isBlank()) {
-                        if (!uiState.isVisibleHistory || uiState.searchHistoryList.isEmpty()) {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    is SearchStateScreen.Success -> {
+                        val results = state.data
+                        if (results != null && uiState.isVisibleResult) {
+                            if (results.isEmpty()) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(24.dp),
+                                    contentAlignment = Alignment.Center,
                                 ) {
-                                    Icon(
-                                        Icons.Default.Search,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(48.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                                    )
                                     Text(
-                                        text = "Введите запрос для поиска",
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        text = "Ничего не найдено",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.primary,
                                     )
+                                }
+                            } else {
+                                LazyColumn(
+                                    modifier = Modifier.fillMaxSize().padding(top = 12.dp),
+                                    verticalArrangement = Arrangement.Top,
+                                    state = scrollState,
+                                ) {
+                                    items(results, key = { it.route.basicData.id }) { routeWithTag ->
+                                        SearchListItem(
+                                            route = routeWithTag.route,
+                                            searchTag = routeWithTag.tag,
+                                            searchValue = queryText,
+                                            entityString = viewModel.entityString,
+                                            onClick = { onRouteClick(routeWithTag.route.basicData) },
+                                        )
+                                    }
+                                }
+                            }
+                        } else if (queryText.isBlank()) {
+                            if (!uiState.isVisibleHistory || uiState.searchHistoryList.isEmpty()) {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    ) {
+                                        Icon(
+                                            Icons.Default.Search,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(48.dp),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                        )
+                                        Text(
+                                            text = "Введите запрос для поиска",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                is SearchStateScreen.Input -> { /* hints shown above */ }
-                is SearchStateScreen.Failure -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "Ошибка поиска: ${state.entity.message ?: "неизвестная ошибка"}",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.error,
-                        )
+                    is SearchStateScreen.Input -> { /* hints shown above */ }
+                    is SearchStateScreen.Failure -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "Ошибка поиска: ${state.entity.message ?: "неизвестная ошибка"}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
                     }
                 }
-            }
 
-            // History with slide + fade animation
-            AnimatedVisibility(
-                modifier = Modifier.fillMaxWidth(),
-                visible = uiState.isVisibleHistory && uiState.searchHistoryList.isNotEmpty() && queryText.isEmpty(),
-                enter = fadeIn(
-                    animationSpec = tween(durationMillis = 500, delayMillis = 300)
-                ) + slideInVertically(
-                    animationSpec = tween(durationMillis = ANIMATION_SLIDE_TIME, delayMillis = 300)
-                ),
-                exit = fadeOut(
-                    animationSpec = tween(durationMillis = 150)
-                ) + slideOutVertically(
-                    animationSpec = tween(durationMillis = ANIMATION_SLIDE_TIME)
-                ),
-            ) {
-                LazyColumn(
+                // History with slide + fade animation
+                androidx.compose.animation.AnimatedVisibility(
                     modifier = Modifier.fillMaxWidth(),
-                    state = scrollState,
+                    visible = uiState.isVisibleHistory && uiState.searchHistoryList.isNotEmpty() && queryText.isEmpty(),
+                    enter = fadeIn(
+                        animationSpec = tween(durationMillis = 500, delayMillis = 300)
+                    ) + slideInVertically(
+                        animationSpec = tween(durationMillis = ANIMATION_SLIDE_TIME, delayMillis = 300)
+                    ),
+                    exit = fadeOut(
+                        animationSpec = tween(durationMillis = 150)
+                    ) + slideOutVertically(
+                        animationSpec = tween(durationMillis = ANIMATION_SLIDE_TIME)
+                    ),
                 ) {
-                    items(uiState.searchHistoryList) { response ->
-                        HistoryItem(
-                            request = response.responseText,
-                            removeOnClick = { viewModel.removeHistoryResponse(response.responseText) },
-                            itemOnClick = {
-                                viewModel.setQueryValue(response.responseText)
-                                viewModel.onSearch()
-                            },
-                        )
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        state = scrollState,
+                    ) {
+                        items(uiState.searchHistoryList) { response ->
+                            HistoryItem(
+                                request = response.responseText,
+                                removeOnClick = { viewModel.removeHistoryResponse(response.responseText) },
+                                itemOnClick = {
+                                    viewModel.setQueryValue(response.responseText)
+                                    viewModel.onSearch()
+                                },
+                            )
+                        }
                     }
                 }
             }

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SelectReleaseDaysScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/SelectReleaseDaysScreen.kt
@@ -13,10 +13,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
@@ -83,6 +82,7 @@ fun SelectReleaseDaysScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
             Text(
@@ -144,26 +144,38 @@ fun SelectReleaseDaysScreen(
 
             Spacer(modifier = Modifier.height(4.dp))
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(7),
+            // Regular grid instead of LazyVerticalGrid to avoid
+            // unbounded height crash on iOS Compose Multiplatform.
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                items(cells) { day ->
-                    ReleaseDayCell(
-                        day = day,
-                        isSelected = day > 0 && selectedDays.contains(day),
-                        onToggle = {
-                            if (day > 0) {
-                                selectedDays = if (selectedDays.contains(day)) {
-                                    selectedDays - day
-                                } else {
-                                    selectedDays + day
-                                }
+                cells.chunked(7).forEach { week ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        week.forEach { day ->
+                            Box(modifier = Modifier.weight(1f)) {
+                                ReleaseDayCell(
+                                    day = day,
+                                    isSelected = day > 0 && selectedDays.contains(day),
+                                    onToggle = {
+                                        if (day > 0) {
+                                            selectedDays = if (selectedDays.contains(day)) {
+                                                selectedDays - day
+                                            } else {
+                                                selectedDays + day
+                                            }
+                                        }
+                                    },
+                                )
                             }
-                        },
-                    )
+                        }
+                        repeat(7 - week.size) {
+                            Box(modifier = Modifier.weight(1f)) {}
+                        }
+                    }
                 }
             }
 

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/WorkScheduleScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/WorkScheduleScreen.kt
@@ -14,9 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -119,6 +116,7 @@ fun WorkScheduleScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
             // Month label
@@ -157,35 +155,44 @@ fun WorkScheduleScreen(
                     CircularProgressIndicator()
                 }
             } else {
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(7),
+                // Regular grid instead of LazyVerticalGrid to avoid
+                // unbounded height crash on iOS Compose Multiplatform.
+                Column(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
-                    items(dayCells) { day ->
-                        val routes = routesByDay[day] ?: emptyList()
-                        val hasRoute = routes.isNotEmpty()
-                        val isSelected = selectedDays.containsKey(day)
-                        val isDeleteSelected = selectedRoutesToDelete.containsKey(day)
-
-                        CalendarDayCell(
-                            day = day,
-                            hasRoute = hasRoute,
-                            routeCount = routes.size,
-                            isSelected = isSelected,
-                            isDeleteSelected = isDeleteSelected,
-                            isDeleteMode = isDeleteMode,
-                            onClick = {
-                                if (day > 0) {
-                                    if (isDeleteMode) {
-                                        viewModel.onDayDeleteClicked(day)
-                                    } else if (activeTime != null) {
-                                        viewModel.togglePlannedTimeForDay(day, activeTime!!)
-                                    }
+                    dayCells.chunked(7).forEach { week ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            week.forEach { day ->
+                                val routes = routesByDay[day] ?: emptyList()
+                                Box(modifier = Modifier.weight(1f)) {
+                                    CalendarDayCell(
+                                        day = day,
+                                        hasRoute = routes.isNotEmpty(),
+                                        routeCount = routes.size,
+                                        isSelected = selectedDays.containsKey(day),
+                                        isDeleteSelected = selectedRoutesToDelete.containsKey(day),
+                                        isDeleteMode = isDeleteMode,
+                                        onClick = {
+                                            if (day > 0) {
+                                                if (isDeleteMode) {
+                                                    viewModel.onDayDeleteClicked(day)
+                                                } else if (activeTime != null) {
+                                                    viewModel.togglePlannedTimeForDay(day, activeTime!!)
+                                                }
+                                            }
+                                        },
+                                    )
                                 }
-                            },
-                        )
+                            }
+                            // Pad remaining cells in last row
+                            repeat(7 - week.size) {
+                                Box(modifier = Modifier.weight(1f)) {}
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
LazyColumn/LazyVerticalGrid/Box(fillMaxSize) inside Column gets Int.MAX_VALUE height constraints on iOS, causing IllegalArgumentException.

- SearchScreen: wrap content area in Box(weight(1f)) for bounded height
- AllRouteScreen: replace fillMaxSize with fillMaxWidth().weight(1f)
- WorkScheduleScreen: replace LazyVerticalGrid with regular Column+Row grid, add verticalScroll to parent Column
- SelectReleaseDaysScreen: same LazyVerticalGrid→regular grid fix