### PR TITLE
feat: add bottom nav, fix colors & MonthPickerSheet on iOS

### DIFF
--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/theme/Color.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/theme/Color.kt
@@ -6,15 +6,87 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
+// ── Dark palette (matches Android app/theme/Color.kt) ──
+
+private val DarkPrimary = Color(0xFFf0f0f0)
+private val DarkOnPrimary = Color(0xFF1A1A1A)
+private val DarkSecondary = Color(0xFF515356)
+private val DarkTertiary = Color(0xFF92b2e5)
+private val DarkSurface = Color(0xFF63666A)
+private val DarkOnSurface = Color(0xFFEBE8E8)
+private val DarkBackground = Color(0xFF333333)
+private val DarkError = Color(0xFFeb9e9e)
+private val DarkSecondaryContainer = Color(0xFF363636)
+private val DarkSurfaceContainerLow = Color(0xFFE7DEBC)
+private val DarkSurfaceContainerHigh = Color(0xFF9D97DC)
+private val SurfaceBrightDark = Color(0xFF99918C)
+private val SurfaceDimDark = Color(0xFF858FA3)
+
+// ── Light palette ──
+
+private val LightPrimary = Color(0xFF383837)
+private val LightOnPrimary = Color(0xFFEFEFEF)
+private val LightSecondary = Color(0xFFF6F5EF)
+private val LightSurface = Color(0xFFe2e0d8)
+private val LightSurfaceVariant = Color(0xFF383837)
+private val LightSurfaceTint = Color(0xFFDEDEDB)
+private val LightOnSurface = Color(0xFFEFEDE3)
+private val LightBackground = Color(0xFFefede3)
+private val LightError = Color(0xFFD05C4A)
+private val LightSecondaryContainer = Color(0xFFEEEEEE)
+private val LightSurfaceContainerLow = Color(0xFF26405c)
+private val LightSurfaceContainerHigh = Color(0xFF9D97DC)
+private val SurfaceBrightLight = Color(0xFFD6C9C1)
+private val SurfaceDimLight = Color(0xFFC0CCE4)
+
+// ── Common ──
+
+private val Blue = Color(0xFF3576FF)
+private val OnError = Color(0xFFFFFFFF)
+
+// ── Color Schemes ──
+
 internal val DarkColorPalette =
     AppColors(
-        materialColors = darkColorScheme(),
+        materialColors = darkColorScheme(
+            primary = DarkPrimary,
+            onPrimary = DarkOnPrimary,
+            secondary = DarkSecondary,
+            secondaryContainer = DarkSecondaryContainer,
+            tertiary = DarkTertiary,
+            surface = DarkSurface,
+            onSurface = DarkOnSurface,
+            background = DarkBackground,
+            error = DarkError,
+            onError = OnError,
+            surfaceBright = SurfaceBrightDark,
+            surfaceDim = SurfaceDimDark,
+            surfaceContainerLow = DarkSurfaceContainerLow,
+            surfaceContainerHigh = DarkSurfaceContainerHigh,
+        ),
         someCustomColor = Color.Red,
     )
 
 internal val LightColorPalette =
     AppColors(
-        materialColors = lightColorScheme(),
+        materialColors = lightColorScheme(
+            primary = LightPrimary,
+            onPrimary = LightOnPrimary,
+            secondary = LightSecondary,
+            secondaryContainer = LightSecondaryContainer,
+            tertiary = Blue,
+            surface = LightSurface,
+            surfaceVariant = LightSurfaceVariant,
+            surfaceTint = LightSurfaceTint,
+            onSurface = LightOnSurface,
+            background = LightBackground,
+            error = LightError,
+            onError = OnError,
+            surfaceBright = SurfaceBrightLight,
+            surfaceDim = SurfaceDimLight,
+            surfaceContainerLow = LightSurfaceContainerLow,
+            surfaceContainerHigh = LightSurfaceContainerHigh,
+        ),
         someCustomColor = Color.Blue,
     )
 

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/component/SharedBottomNavigationBar.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/component/SharedBottomNavigationBar.kt
@@ -1,0 +1,65 @@
+package com.z_company.shared.ui.component
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Wallet
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Нижняя навигация — зеркало Android BottomNavigationBar.
+ *
+ * 5 вкладок: Главная, Зарплата, Добавить, Настройки, Профиль.
+ * Использует Material 3 NavigationBar (кросс-платформенный).
+ */
+
+enum class BottomTab(
+    val label: String,
+    val icon: ImageVector,
+) {
+    Home("Главная", Icons.Default.Home),
+    Salary("Зарплата", Icons.Default.Wallet),
+    Add("Добавить", Icons.Default.AddCircle),
+    Settings("Настройки", Icons.Default.Settings),
+    Profile("Профиль", Icons.Default.AccountCircle),
+}
+
+@Composable
+fun SharedBottomNavigationBar(
+    currentTab: BottomTab,
+    onTabSelected: (BottomTab) -> Unit,
+) {
+    NavigationBar(
+        containerColor = MaterialTheme.colorScheme.secondary,
+    ) {
+        BottomTab.entries.forEach { tab ->
+            NavigationBarItem(
+                selected = currentTab == tab,
+                onClick = { onTabSelected(tab) },
+                icon = {
+                    Icon(
+                        imageVector = tab.icon,
+                        contentDescription = tab.label,
+                    )
+                },
+                label = { Text(tab.label) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    selectedTextColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    unselectedIconColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+                    unselectedTextColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+                    indicatorColor = MaterialTheme.colorScheme.secondary,
+                ),
+            )
+        }
+    }
+}

--- a/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/HomeScreen.kt
+++ b/features/shared/src/commonMain/kotlin/com/z_company/shared/ui/screen/HomeScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -351,12 +350,6 @@ fun HomeScreen(
             }
         }
 
-        // FAB
-        Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
-            FloatingActionButton(modifier = Modifier.padding(16.dp), onClick = onNewRouteClick) {
-                Icon(Icons.Default.Add, contentDescription = "Новый маршрут")
-            }
-        }
     }
 }
 
@@ -753,6 +746,13 @@ private fun MonthPickerSheet(
     var selectedMonth by remember { mutableIntStateOf(currentMonth.month) }
     var selectedYear by remember { mutableIntStateOf(currentMonth.year) }
 
+    // Fallback: if DB is empty (fresh install), show all 12 months and nearby years
+    val effectiveMonthList = monthList.ifEmpty { (0..11).toList() }
+    val effectiveYearList = yearList.ifEmpty {
+        val curYear = currentMonth.year
+        listOf(curYear - 1, curYear, curYear + 1)
+    }
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
@@ -761,13 +761,13 @@ private fun MonthPickerSheet(
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
             Text("Выберите месяц и год", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(bottom = 12.dp))
             FlowRow(modifier = Modifier.fillMaxWidth().padding(8.dp), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                monthList.forEach { m ->
+                effectiveMonthList.forEach { m ->
                     FilterChip(selected = selectedMonth == m, onClick = { selectedMonth = m }, label = { Text(MonthFullText.getMonthFullText(m)) })
                 }
             }
             Spacer(modifier = Modifier.height(8.dp))
             FlowRow(modifier = Modifier.fillMaxWidth().padding(8.dp), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                yearList.forEach { y ->
+                effectiveYearList.forEach { y ->
                     FilterChip(selected = selectedYear == y, onClick = { selectedYear = y }, label = { Text("$y") })
                 }
             }

--- a/iosApp/src/commonMain/kotlin/com/z_company/iosapp/App.kt
+++ b/iosApp/src/commonMain/kotlin/com/z_company/iosapp/App.kt
@@ -1,11 +1,11 @@
 package com.z_company.iosapp
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.z_company.iosapp.navigation.AppNavHost
+import com.z_company.shared.theme.LocoAppTheme
 
 /**
  * Корневой Composable iOS-приложения.
@@ -15,7 +15,7 @@ import com.z_company.iosapp.navigation.AppNavHost
  */
 @Composable
 fun App() {
-    MaterialTheme {
+    LocoAppTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
             AppNavHost()
         }

--- a/iosApp/src/commonMain/kotlin/com/z_company/iosapp/navigation/AppNavHost.kt
+++ b/iosApp/src/commonMain/kotlin/com/z_company/iosapp/navigation/AppNavHost.kt
@@ -1,12 +1,19 @@
 package com.z_company.iosapp.navigation
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.savedstate.read
+import com.z_company.shared.ui.component.BottomTab
+import com.z_company.shared.ui.component.SharedBottomNavigationBar
 
 // All screens from :features:shared
 import com.z_company.shared.ui.screen.AllRouteScreen as SharedAllRouteScreen
@@ -29,7 +36,25 @@ import com.z_company.shared.ui.screen.WorkScheduleScreen as SharedWorkScheduleSc
  * Корневой NavHost iOS-приложения.
  *
  * Все экраны теперь используются из :features:shared.
+ * Scaffold с нижней навигацией показывается только на основных экранах.
  */
+
+// Маршруты, на которых показывается нижняя навигация
+private val bottomBarRoutes = setOf(
+    HomeRoute.route,
+    SalaryCalculationRoute.route,
+    SettingsScreenRoute.route,
+    ProfileRoute.route,
+)
+
+// Маппинг маршрута навигации → таб
+private fun routeToTab(route: String?): BottomTab = when (route) {
+    SalaryCalculationRoute.route -> BottomTab.Salary
+    SettingsScreenRoute.route -> BottomTab.Settings
+    ProfileRoute.route -> BottomTab.Profile
+    else -> BottomTab.Home
+}
+
 @Composable
 fun AppNavHost() {
     val navController = rememberNavController()
@@ -39,129 +64,163 @@ fun AppNavHost() {
         router.navController = navController
     }
 
-    NavHost(
-        navController = navController,
-        startDestination = HomeRoute.route,
-    ) {
-        composable(HomeRoute.route) {
-            SharedHomeScreen(
-                onRouteClick = { routeId -> router.showRouteForm(routeId) },
-                onNewRouteClick = { router.showRouteForm() },
-                onSettingsClick = { router.showSettings() },
-                onSalaryClick = { router.showSalaryCalculation() },
-                onAllRouteClick = { router.showAllRoute() },
-                onWorkScheduleClick = { router.showWorkScheduleScreen() },
-                onSearchClick = { router.showSearch() },
-                onMoreInfoClick = { monthId -> router.showMoreInfo(monthId) },
-            )
-        }
-        composable(FormRoute.route) { backStackEntry ->
-            val routeId = backStackEntry.arguments?.read {
-                if (contains("routeId")) getString("routeId") else null
-            }
-            SharedFormRouteScreen(
-                routeId = routeId,
-                onBackClick = { router.back() },
-                onLocoClick = { locoId, basicId ->
-                    navController.navigate(FormLoco.buildRoute(locoId, basicId))
-                },
-                onNewLocoClick = { basicId -> router.showEmptyLocoForm(basicId) },
-                onTrainClick = { trainId, basicId ->
-                    navController.navigate(FormTrain.buildRoute(trainId, basicId))
-                },
-                onNewTrainClick = { basicId -> router.showEmptyTrainForm(basicId) },
-                onPassengerClick = { passengerId, basicId ->
-                    navController.navigate(FormPassenger.buildRoute(passengerId, basicId))
-                },
-                onNewPassengerClick = { basicId -> router.showEmptyPassengerForm(basicId) },
-            )
-        }
-        composable(FormLoco.route) { backStackEntry ->
-            val basicId = backStackEntry.arguments?.read {
-                if (contains("basicId")) getString("basicId") else null
-            } ?: ""
-            val locoId = backStackEntry.arguments?.read {
-                if (contains("locoId")) getString("locoId") else null
-            }
-            SharedFormLocoScreen(locoId = locoId, basicId = basicId, onBackClick = { router.back() })
-        }
-        composable(FormTrain.route) { backStackEntry ->
-            val basicId = backStackEntry.arguments?.read {
-                if (contains("basicId")) getString("basicId") else null
-            } ?: ""
-            val trainId = backStackEntry.arguments?.read {
-                if (contains("trainId")) getString("trainId") else null
-            }
-            SharedFormTrainScreen(trainId = trainId, basicId = basicId, onBackClick = { router.back() })
-        }
-        composable(FormPassenger.route) { backStackEntry ->
-            val basicId = backStackEntry.arguments?.read {
-                if (contains("basicId")) getString("basicId") else null
-            } ?: ""
-            val passengerId = backStackEntry.arguments?.read {
-                if (contains("passengerId")) getString("passengerId") else null
-            }
-            SharedFormPassengerScreen(passengerId = passengerId, basicId = basicId, onBackClick = { router.back() })
-        }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+    val showBottomBar = currentRoute in bottomBarRoutes
 
-        composable(SettingsScreenRoute.route) {
-            SharedSettingsScreen(
-                onBackClick = { router.back() },
-                onShowSettingSalary = { router.showSettingSalary() },
-            )
-        }
-        composable(ProfileRoute.route) {
-            SharedProfileScreen(
-                onBackClick = { router.back() },
-                onPurchasesClick = { router.showPurchasesScreen() },
-            )
-        }
-        composable(SalaryCalculationRoute.route) {
-            SharedSalaryCalculationScreen(
-                onBackClick = { router.back() },
-                onShowSettingSalary = { router.showSettingSalary() },
-            )
-        }
-        composable(SettingSalaryRoute.route) {
-            SharedSettingSalaryScreen(
-                onBackClick = { router.back() },
-            )
-        }
-        composable(SearchRoute.route) {
-            SharedSearchScreen(
-                onBackClick = { router.back() },
-                onRouteClick = { basicData -> router.showRouteDetails(basicData) },
-            )
-        }
-        composable(PurchasesRoute.route) {
-            SharedPurchasesScreen(
-                onBackClick = { router.back() },
-            )
-        }
-        composable(AllRouteScreenRoute.route) {
-            SharedAllRouteScreen(
-                onBackClick = { router.back() },
-                onRouteClick = { basicData -> router.showRouteDetails(basicData) },
-            )
-        }
-        composable(WorkScheduleScreenRoute.route) {
-            SharedWorkScheduleScreen(
-                onBackClick = { router.back() },
-            )
-        }
-        composable(SelectReleaseDaysScreenRoute.route) {
-            SharedSelectReleaseDaysScreen(
-                onBackClick = { router.back() },
-            )
-        }
-        composable(MoreInfoRoute.route) { backStackEntry ->
-            val monthId = backStackEntry.arguments?.read {
-                if (contains("monthId")) getString("monthId") else null
+    Scaffold(
+        bottomBar = {
+            if (showBottomBar) {
+                SharedBottomNavigationBar(
+                    currentTab = routeToTab(currentRoute),
+                    onTabSelected = { tab ->
+                        val targetRoute = when (tab) {
+                            BottomTab.Home -> HomeRoute.route
+                            BottomTab.Salary -> SalaryCalculationRoute.route
+                            BottomTab.Add -> {
+                                router.showRouteForm()
+                                return@SharedBottomNavigationBar
+                            }
+                            BottomTab.Settings -> SettingsScreenRoute.route
+                            BottomTab.Profile -> ProfileRoute.route
+                        }
+                        if (targetRoute != currentRoute) {
+                            navController.navigate(targetRoute) {
+                                popUpTo(HomeRoute.route) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    },
+                )
             }
-            SharedMoreInfoScreen(
-                monthId = monthId,
-                onBackClick = { router.back() },
-            )
+        },
+    ) { padding ->
+        NavHost(
+            navController = navController,
+            startDestination = HomeRoute.route,
+            modifier = Modifier.padding(padding),
+        ) {
+            composable(HomeRoute.route) {
+                SharedHomeScreen(
+                    onRouteClick = { routeId -> router.showRouteForm(routeId) },
+                    onNewRouteClick = { router.showRouteForm() },
+                    onSettingsClick = { router.showSettings() },
+                    onSalaryClick = { router.showSalaryCalculation() },
+                    onAllRouteClick = { router.showAllRoute() },
+                    onWorkScheduleClick = { router.showWorkScheduleScreen() },
+                    onSearchClick = { router.showSearch() },
+                    onMoreInfoClick = { monthId -> router.showMoreInfo(monthId) },
+                )
+            }
+            composable(FormRoute.route) { backStackEntry ->
+                val routeId = backStackEntry.arguments?.read {
+                    if (contains("routeId")) getString("routeId") else null
+                }
+                SharedFormRouteScreen(
+                    routeId = routeId,
+                    onBackClick = { router.back() },
+                    onLocoClick = { locoId, basicId ->
+                        navController.navigate(FormLoco.buildRoute(locoId, basicId))
+                    },
+                    onNewLocoClick = { basicId -> router.showEmptyLocoForm(basicId) },
+                    onTrainClick = { trainId, basicId ->
+                        navController.navigate(FormTrain.buildRoute(trainId, basicId))
+                    },
+                    onNewTrainClick = { basicId -> router.showEmptyTrainForm(basicId) },
+                    onPassengerClick = { passengerId, basicId ->
+                        navController.navigate(FormPassenger.buildRoute(passengerId, basicId))
+                    },
+                    onNewPassengerClick = { basicId -> router.showEmptyPassengerForm(basicId) },
+                )
+            }
+            composable(FormLoco.route) { backStackEntry ->
+                val basicId = backStackEntry.arguments?.read {
+                    if (contains("basicId")) getString("basicId") else null
+                } ?: ""
+                val locoId = backStackEntry.arguments?.read {
+                    if (contains("locoId")) getString("locoId") else null
+                }
+                SharedFormLocoScreen(locoId = locoId, basicId = basicId, onBackClick = { router.back() })
+            }
+            composable(FormTrain.route) { backStackEntry ->
+                val basicId = backStackEntry.arguments?.read {
+                    if (contains("basicId")) getString("basicId") else null
+                } ?: ""
+                val trainId = backStackEntry.arguments?.read {
+                    if (contains("trainId")) getString("trainId") else null
+                }
+                SharedFormTrainScreen(trainId = trainId, basicId = basicId, onBackClick = { router.back() })
+            }
+            composable(FormPassenger.route) { backStackEntry ->
+                val basicId = backStackEntry.arguments?.read {
+                    if (contains("basicId")) getString("basicId") else null
+                } ?: ""
+                val passengerId = backStackEntry.arguments?.read {
+                    if (contains("passengerId")) getString("passengerId") else null
+                }
+                SharedFormPassengerScreen(passengerId = passengerId, basicId = basicId, onBackClick = { router.back() })
+            }
+
+            composable(SettingsScreenRoute.route) {
+                SharedSettingsScreen(
+                    onBackClick = { router.back() },
+                    onShowSettingSalary = { router.showSettingSalary() },
+                )
+            }
+            composable(ProfileRoute.route) {
+                SharedProfileScreen(
+                    onBackClick = { router.back() },
+                    onPurchasesClick = { router.showPurchasesScreen() },
+                )
+            }
+            composable(SalaryCalculationRoute.route) {
+                SharedSalaryCalculationScreen(
+                    onBackClick = { router.back() },
+                    onShowSettingSalary = { router.showSettingSalary() },
+                )
+            }
+            composable(SettingSalaryRoute.route) {
+                SharedSettingSalaryScreen(
+                    onBackClick = { router.back() },
+                )
+            }
+            composable(SearchRoute.route) {
+                SharedSearchScreen(
+                    onBackClick = { router.back() },
+                    onRouteClick = { basicData -> router.showRouteDetails(basicData) },
+                )
+            }
+            composable(PurchasesRoute.route) {
+                SharedPurchasesScreen(
+                    onBackClick = { router.back() },
+                )
+            }
+            composable(AllRouteScreenRoute.route) {
+                SharedAllRouteScreen(
+                    onBackClick = { router.back() },
+                    onRouteClick = { basicData -> router.showRouteDetails(basicData) },
+                )
+            }
+            composable(WorkScheduleScreenRoute.route) {
+                SharedWorkScheduleScreen(
+                    onBackClick = { router.back() },
+                )
+            }
+            composable(SelectReleaseDaysScreenRoute.route) {
+                SharedSelectReleaseDaysScreen(
+                    onBackClick = { router.back() },
+                )
+            }
+            composable(MoreInfoRoute.route) { backStackEntry ->
+                val monthId = backStackEntry.arguments?.read {
+                    if (contains("monthId")) getString("monthId") else null
+                }
+                SharedMoreInfoScreen(
+                    monthId = monthId,
+                    onBackClick = { router.back() },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
- Copy Android color palette to shared Color.kt (dark+light schemes)
- Use LocoAppTheme instead of bare MaterialTheme in iOS App.kt
- Add SharedBottomNavigationBar with 5 tabs (Home, Salary, Add, Settings, Profile)
- Wrap AppNavHost in Scaffold with bottom bar on main routes
- Remove FAB from HomeScreen (Android uses bottom nav instead)
- Add fallback months/years in MonthPickerSheet for fresh installs