### PR TITLE
feat(shared-route): tentative save with isDeleted=true flag

### DIFF
--- a/app/src/main/java/com/z_company/loco_driver/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/z_company/loco_driver/viewmodel/MainViewModel.kt
@@ -127,9 +127,10 @@ class MainViewModel : ViewModel(), KoinComponent, DefaultLifecycleObserver {
      * Обрабатывает deep-link `locodriver://share/{shareId}`:
      * 1. Загружает Route с сервера
      * 2. Переприсваивает идентификаторы
-     * 3. Помещает Route в [SharedRouteHolder] (не сохраняя в БД)
-     * 4. Навигирует на FormScreen через [pendingOpenFormWithId]
-     * FormViewModel при загрузке проверит SharedRouteHolder и покажет шторку.
+     * 3. Сохраняет Route в локальную БД с флагом [isDeleted = true] — «tentative»
+     *    (не отображается в списках, но доступен по id, child-сущности работают)
+     * 4. Помечает id в [SharedRouteHolder] для FormViewModel (покажет шторку)
+     * 5. Навигирует на FormScreen через [pendingOpenFormWithId]
      */
     fun handleShareDeepLink(shareId: String) {
         if (shareId.isBlank()) return
@@ -138,9 +139,23 @@ class MainViewModel : ViewModel(), KoinComponent, DefaultLifecycleObserver {
                 shareRouteManager.getSharedRoute(shareId).collect { result ->
                     when (result) {
                         is ResultState.Success -> {
+                            // Переприсваиваем id + ставим isDeleted = true (tentative)
                             val imported = result.data.reidentifyForImport()
-                            SharedRouteHolder.set(imported)
-                            _pendingOpenFormWithId.value = imported.basicData.id
+                            val tentative = imported.copy(
+                                basicData = imported.basicData.copy(isDeleted = true)
+                            )
+                            // Сохраняем в БД (tentative)
+                            routeUseCase.saveRoute(tentative).collect { saveState ->
+                                if (saveState is ResultState.Success) {
+                                    SharedRouteHolder.markSharedPreview(tentative.basicData.id)
+                                    _pendingOpenFormWithId.value = tentative.basicData.id
+                                } else if (saveState is ResultState.Error) {
+                                    snackbarManager.show(
+                                        saveState.entity.message
+                                            ?: "Ошибка импорта маршрута"
+                                    )
+                                }
+                            }
                         }
                         is ResultState.Error -> {
                             snackbarManager.show(

--- a/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/SyncManager.kt
+++ b/data_remote/src/commonMain/kotlin/com/z_company/repository/remote_rest/SyncManager.kt
@@ -135,6 +135,14 @@ class SyncManager(
         for (route in deletedRoutes) {
             val routeId = route.basicData.id
             val label = routeLabel(route)
+            // Если маршрут никогда не был загружен на сервер (remoteRouteId is null/blank) —
+            // не трогаем его: сервер о нём ничего не знает, а локально он уже помечен
+            // isDeleted=true и скрыт из списков. Это защищает shared-preview маршруты
+            // (импортированные по публичной ссылке и ожидающие решения пользователя)
+            // от случайного удаления во время sync-а.
+            if (route.basicData.remoteRouteId.isNullOrBlank()) {
+                continue
+            }
             try {
                 routesManager.deleteRouteInRemote(routeId, bearerToken)
                     .collect { deleteResult ->

--- a/domain/src/commonMain/kotlin/com/z_company/domain/util/SharedRouteHolder.kt
+++ b/domain/src/commonMain/kotlin/com/z_company/domain/util/SharedRouteHolder.kt
@@ -1,28 +1,34 @@
 package com.z_company.domain.util
 
-import com.z_company.domain.entities.route.Route
-
 /**
- * Временное хранилище Route для передачи между ViewModel-ами
- * при импорте маршрута по публичной ссылке.
+ * Хранит id маршрута, только что импортированного по публичной ссылке.
  *
- * MainViewModel загружает Route с сервера, помещает его сюда через [set],
- * затем навигирует на FormScreen. FormViewModel в loadData() проверяет
- * [consume] — если Route с подходящим id есть, использует его напрямую,
- * минуя загрузку из БД (маршрут ещё не сохранён).
+ * Маршрут уже сохранён в локальную БД с флагом [isDeleted = true]
+ * (tentative preview — не отображается в списках, но доступен через
+ * [RouteRepository.loadRoute] по id, и его дочерние сущности
+ * грузятся нормально).
+ *
+ * FormViewModel при загрузке проверяет [consume] — если id совпадает,
+ * помечает `isSharedPreview = true`, чтобы показать шторку.
  */
 object SharedRouteHolder {
     @Volatile
-    private var _route: Route? = null
+    private var _sharedRouteId: String? = null
 
-    fun set(route: Route) { _route = route }
-
-    /** Возвращает Route и очищает хранилище (one-shot). */
-    fun consume(): Route? {
-        val r = _route
-        _route = null
-        return r
+    /** Пометить маршрут как импортированный по публичной ссылке. */
+    fun markSharedPreview(routeId: String) {
+        _sharedRouteId = routeId
     }
 
-    fun peek(): Route? = _route
+    /**
+     * Если переданный id помечен как shared preview — очистить метку и вернуть true.
+     * Вызывается из FormViewModel.loadData ровно один раз для экземпляра FormViewModel.
+     */
+    fun consume(routeId: String): Boolean {
+        if (_sharedRouteId == routeId) {
+            _sharedRouteId = null
+            return true
+        }
+        return false
+    }
 }

--- a/features/route/src/main/java/com/z_company/route/viewmodel/FormViewModel.kt
+++ b/features/route/src/main/java/com/z_company/route/viewmodel/FormViewModel.kt
@@ -233,13 +233,10 @@ class FormViewModel(
     private fun loadData() {
         loadRouteJob?.cancel()
         loadRouteJob = viewModelScope.launch(Dispatchers.IO) {
-            // Проверяем SharedRouteHolder — маршрут по публичной ссылке (ещё не в БД)
-            val sharedRoute = SharedRouteHolder.consume()
-            if (sharedRoute != null && sharedRoute.basicData.id == routeId) {
-                _currentRoute.value = sharedRoute
+            // Проверяем: это маршрут импортированный по публичной ссылке (tentative preview)
+            // Маршрут уже лежит в БД с isDeleted=true, грузится как обычно ниже.
+            if (routeId != null && SharedRouteHolder.consume(routeId)) {
                 _isSharedPreview.value = true
-                _uiState.update { it.copy(routeDetailState = ResultState.Success(sharedRoute)) }
-                return@launch
             }
 
             if (isNewRoute) {
@@ -676,10 +673,18 @@ class FormViewModel(
         saveRouteJob?.cancel()
         saveRouteJob = viewModelScope.launch(Dispatchers.IO) {
             currentRoute.value?.let { route ->
-                routeUseCase.saveRoute(route).collectLatest { result ->
+                // Если это shared preview (tentative с isDeleted=true) — снимаем флаг,
+                // маршрут становится обычным сохранённым.
+                val routeToSave = if (_isSharedPreview.value || route.basicData.isDeleted) {
+                    route.copy(basicData = route.basicData.copy(isDeleted = false))
+                } else {
+                    route
+                }
+                routeUseCase.saveRoute(routeToSave).collectLatest { result ->
                     Log.d("zzz", "saveResult $result")
                     _uiState.update { it.copy(saveRouteState = result) }
                     if (result is ResultState.Success) {
+                        _isSharedPreview.value = false
                         deletedLocoList.forEach { loco ->
                             locoUseCase.removeLoco(loco).collect {}
                         }
@@ -840,14 +845,17 @@ class FormViewModel(
     }
 
     /**
-     * Сохранить shared-маршрут и выйти без мерцания.
+     * Сохранить shared-маршрут (снять флаг isDeleted) и выйти без мерцания.
      * Сразу ставит exitFromScreen=true, сохранение идёт в фоне.
      */
     fun saveSharedRouteAndExit() {
         _isSharedPreview.value = false
         _currentRoute.value?.let { route ->
+            val confirmed = route.copy(
+                basicData = route.basicData.copy(isDeleted = false)
+            )
             viewModelScope.launch(Dispatchers.IO) {
-                routeUseCase.saveRoute(route).collect {}
+                routeUseCase.saveRoute(confirmed).collect {}
             }
         }
         _uiState.update { it.copy(exitFromScreen = true) }


### PR DESCRIPTION
Проблема: shared-маршрут не сохранялся сразу, из-за чего при открытии локомотива/поезда/пассажира показывался пустой экран (child-сущности грузятся из БД по basicId, а родительский Route там ещё не было).

Решение: при получении ссылки сразу сохраняем маршрут в БД, но с флагом isDeleted=true («tentative preview»). SQL-запросы getAll/getByPeriod уже фильтруют isDeleted=0, так что маршрут скрыт из HomeScreen/AllRoute, но getById (используется FormScreen) его возвращает, и child-сущности доступны нормально.

Flow:
- handleShareDeepLink: fetch → reidentify → isDeleted=true → saveRoute → SharedRouteHolder.markSharedPreview(id) → navigate to FormRoute
- FormViewModel.loadData: проверяет SharedRouteHolder.consume(routeId), устанавливает _isSharedPreview=true. Route загружается из БД как обычно.
- FormViewModel.saveRoute: при shared preview снимает isDeleted=false перед сохранением — маршрут становится обычным видимым.
- FormViewModel.saveSharedRouteAndExit: аналогично.
- Back/Отмена: маршрут остаётся в БД с isDeleted=true, не виден в списках.

SyncManager guard:
- В шаге 4 (удаление isDeleted-маршрутов с сервера) пропускаем маршруты с remoteRouteId.isNullOrBlank() — сервер о них не знает, а локально они могут быть shared-preview, ожидающими решения пользователя.

Изменения:
- SharedRouteHolder: теперь хранит только id, а не весь Route
- MainViewModel.handleShareDeepLink: save tentative + markSharedPreview
- FormViewModel.loadData: проверяет флаг shared preview
- FormViewModel.saveRoute + saveSharedRouteAndExit: снимают isDeleted
- SyncManager: пропускает удаление local-only isDeleted маршрутов

https://claude.ai/code/session_01XCkh15r1rquLc5PBuQejgN